### PR TITLE
Webhook: support {text}/{timestamp}/{json} URL placeholders

### DIFF
--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -700,23 +700,47 @@ function sendToAI(text, isFollowup, cfg, cb) {
 // CUSTOM WEBHOOK
 // ============================================================================
 
+function buildWebhookPayload(text) {
+    return {
+        text:      text,
+        timestamp: Math.floor(Date.now() / 1000)
+    };
+}
+
+// Substitute {text}/{timestamp}/{json} placeholders in a webhook URL. Returns
+// the URL unchanged when it has no placeholders.
+function applyWebhookTemplate(url, payload) {
+    var json = encodeURIComponent(JSON.stringify(payload));
+    return url
+        .replace(/\{text\}/g, encodeURIComponent(payload.text))
+        .replace(/\{timestamp\}/g, String(payload.timestamp))
+        .replace(/\{json\}/g, json);
+}
+
+// Templated URL wins; else for GET append text/timestamp query params as before.
+function buildWebhookUrl(url, verb, payload) {
+    var templatedUrl = applyWebhookTemplate(url, payload);
+    if (templatedUrl !== url) return templatedUrl;
+    if (verb !== 'GET') return url;
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') +
+        'text=' + encodeURIComponent(payload.text) +
+        '&timestamp=' + payload.timestamp;
+}
+
 function sendToWebhook(text, cfg, cb) {
     var url   = cfg.webhook_url;
     var verb  = (cfg.webhook_verb  || 'POST').toUpperCase();
     var token = cfg.webhook_token;
     if (!url) { cb(false, 'Webhook not configured'); return; }
 
-    var payload = {
-        text:      text,
-        timestamp: Math.floor(Date.now() / 1000)
-    };
+    var payload  = buildWebhookPayload(text);
+    var finalUrl = buildWebhookUrl(url, verb, payload);
 
     var xhr = new XMLHttpRequest();
     if (verb === 'GET') {
-        xhr.open('GET', url + '?text=' + encodeURIComponent(text) +
-                        '&timestamp=' + payload.timestamp);
+        xhr.open('GET', finalUrl);
     } else {
-        xhr.open(verb, url);
+        xhr.open(verb, finalUrl);
         xhr.setRequestHeader('Content-Type', 'application/json');
     }
     if (token) xhr.setRequestHeader('Authorization', 'Bearer ' + token);
@@ -1363,6 +1387,7 @@ Pebble.addEventListener('showConfiguration', function() {
     ' Custom Webhook</label>' +
     '<div class="fields">' +
     'URL:<input type="text" id="webhook_url" value=\'' + esc(cfg.webhook_url) + '\'>' +
+    '<p class="note">Supports URL placeholders: <code>{text}</code>, <code>{timestamp}</code>, <code>{json}</code>. AutoRemote example: <code>message=brain_dump=:={json}</code></p>' +
     'Method:<select id="webhook_verb">' +
     '<option value="POST"  ' + sel(cfg.webhook_verb,'POST')  + '>POST</option>' +
     '<option value="PUT"   ' + sel(cfg.webhook_verb,'PUT')   + '>PUT</option>' +

--- a/test/webhookTemplate.test.js
+++ b/test/webhookTemplate.test.js
@@ -1,0 +1,100 @@
+// Unit tests for webhook URL templating helpers (Brain Dump pkjs)
+// Run: node test/webhookTemplate.test.js
+
+function buildWebhookPayload(text, timestamp) {
+    return {
+        text: text,
+        timestamp: timestamp
+    };
+}
+
+function applyWebhookTemplate(url, payload) {
+    var json = encodeURIComponent(JSON.stringify(payload));
+    return url
+        .replace(/\{text\}/g, encodeURIComponent(payload.text))
+        .replace(/\{timestamp\}/g, String(payload.timestamp))
+        .replace(/\{json\}/g, json);
+}
+
+function buildWebhookUrl(url, verb, payload) {
+    var templatedUrl = applyWebhookTemplate(url, payload);
+    if (templatedUrl !== url) return templatedUrl;
+    if (verb !== 'GET') return url;
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') +
+        'text=' + encodeURIComponent(payload.text) +
+        '&timestamp=' + payload.timestamp;
+}
+
+var passed = 0;
+var failed = 0;
+
+function check(label, got, expected) {
+    if (got === expected) {
+        passed++;
+        process.stdout.write('  ✓ ' + label + '\n');
+    } else {
+        failed++;
+        process.stdout.write('  ✗ ' + label + '\n      got: ' + got + '\n expected: ' + expected + '\n');
+    }
+}
+
+function checkObject(label, got, expected) {
+    var g = JSON.stringify(got);
+    var e = JSON.stringify(expected);
+    check(label, g, e);
+}
+
+function section(name) {
+    process.stdout.write('\n' + name + '\n');
+}
+
+var payload = buildWebhookPayload('Quote " and spaces', 1770000000);
+
+section('Template placeholders');
+check(
+    '{text} URL-encodes note text',
+    applyWebhookTemplate('https://x.test/hook?text={text}', payload),
+    'https://x.test/hook?text=Quote%20%22%20and%20spaces'
+);
+check(
+    '{timestamp} inserts unix seconds',
+    applyWebhookTemplate('https://x.test/hook?ts={timestamp}', payload),
+    'https://x.test/hook?ts=1770000000'
+);
+checkObject(
+    '{json} round-trips through decodeURIComponent',
+    JSON.parse(decodeURIComponent(applyWebhookTemplate('{json}', payload))),
+    payload
+);
+
+section('GET fallback');
+check(
+    'GET without placeholders appends query on bare URL',
+    buildWebhookUrl('https://x.test/hook', 'GET', payload),
+    'https://x.test/hook?text=Quote%20%22%20and%20spaces&timestamp=1770000000'
+);
+check(
+    'GET without placeholders appends with & when query exists',
+    buildWebhookUrl('https://x.test/hook?key=abc', 'GET', payload),
+    'https://x.test/hook?key=abc&text=Quote%20%22%20and%20spaces&timestamp=1770000000'
+);
+
+section('AutoRemote-style URL');
+var autoRemoteUrl = buildWebhookUrl(
+    'https://autoremotejoaomgcd.appspot.com/sendmessage?key=KEY&message=brain_dump=:={json}',
+    'GET',
+    payload
+);
+check(
+    'Templated GET URL keeps AutoRemote query layout',
+    autoRemoteUrl.indexOf('message=brain_dump=:=') >= 0 ? 'yes' : 'no',
+    'yes'
+);
+checkObject(
+    'AutoRemote payload decodes to valid JSON',
+    JSON.parse(decodeURIComponent(autoRemoteUrl.split('=:=')[1])),
+    payload
+);
+
+process.stdout.write('\nPassed: ' + passed + '  Failed: ' + failed + '\n');
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Templated webhook URLs (e.g. AutoRemote message=brain_dump=:={json}). When the URL has no placeholders, GET still appends text/timestamp query params as before. Adds config-page note and template unit tests.

Ported from https://github.com/adrienthiery/pebble-watchface-agent-skill/pull/3 after repo separation

cc @justcarver 