### PR TITLE
Add Nextcloud Tasks destination + two-way webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.lock-waf*

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "NOTE_IS_CLASSIFY_ONLY",
       "DUE_LABEL",
       "EXTERNAL_ID",
-      "COMPLETE_TASK"
+      "COMPLETE_TASK",
+      "WEBHOOK_MSG"
     ],
     "resources": {
       "media": [

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -45,6 +45,7 @@
 #define DEST_LOCAL   4   // on-watch reminders list (no phone needed)
 #define DEST_TODOIST    5
 #define DEST_NEXTCLOUD  6
+#define DEST_NEXTCLOUD_TASKS 7
 
 // Destination bitmask bits (must match pkjs DEST_MASK)
 #define DEST_BIT_TASKS     (1 << DEST_TASKS)
@@ -53,6 +54,7 @@
 #define DEST_BIT_WEBHOOK   (1 << DEST_WEBHOOK)
 #define DEST_BIT_TODOIST   (1 << DEST_TODOIST)
 #define DEST_BIT_NEXTCLOUD (1 << DEST_NEXTCLOUD)
+#define DEST_BIT_NEXTCLOUD_TASKS (1 << DEST_NEXTCLOUD_TASKS)
 
 // Ink theme — strict black & white
 #define C_SCREEN   GColorBlack
@@ -177,6 +179,7 @@ static DictationSession *s_dictation_session;
 static char s_note_buf[NOTE_BUF_SIZE];
 static char s_ai_response_buf[NOTE_BUF_SIZE];
 static char s_status_buf[STATUS_BUF_SIZE];
+static char s_webhook_msg_buf[120];   // two-way webhook reply shown on success screen
 static char s_conversation_buf[CONV_BUF_SIZE];
 static int  s_conv_loading_at = -1;   // offset of "..." in s_conversation_buf
 
@@ -304,7 +307,8 @@ static const char *dest_full_name(int dest) {
         case DEST_WEBHOOK:   return "Webhook";
         case DEST_LOCAL:     return "Local Note";
         case DEST_TODOIST:   return "Todoist";
-        case DEST_NEXTCLOUD: return "Nextcloud";
+        case DEST_NEXTCLOUD: return "Nextcloud Notes";
+        case DEST_NEXTCLOUD_TASKS: return "Nextcloud Tasks";
         default:             return "?";
     }
 }
@@ -760,6 +764,7 @@ static void inbox_received_callback(DictionaryIterator *iter, void *context) {
         if (ok == 1) {
             Tuple *dest_t = dict_find(iter, MESSAGE_KEY_DEST_USED);
             int dest = dest_t ? (int)dest_t->value->int32 : 0;
+            s_webhook_msg_buf[0] = '\0';
             if (dest == DEST_LOCAL) {
                 reminders_add(s_note_buf);
                 set_status("Saved locally ✓");
@@ -768,6 +773,12 @@ static void inbox_received_callback(DictionaryIterator *iter, void *context) {
                 const char *ext_id = (ext_t && ext_t->value->cstring[0])
                                      ? ext_t->value->cstring : NULL;
                 history_save_item(s_note_buf, NULL, dest, ext_id);
+                // Two-way webhook: stash the endpoint's reply to show on the success screen.
+                Tuple *webhook_msg_t = dict_find(iter, MESSAGE_KEY_WEBHOOK_MSG);
+                if (webhook_msg_t && webhook_msg_t->value->cstring[0]) {
+                    strncpy(s_webhook_msg_buf, webhook_msg_t->value->cstring, sizeof(s_webhook_msg_buf) - 1);
+                    s_webhook_msg_buf[sizeof(s_webhook_msg_buf) - 1] = '\0';
+                }
                 char msg[STATUS_BUF_SIZE];
                 snprintf(msg, sizeof(msg), "Sent → %s ✓", dest_full_name(dest));
                 set_status(msg);
@@ -1071,6 +1082,7 @@ static void draw_dest_glyph(GContext *ctx, int dest, GPoint c, GColor fg) {
         case DEST_TODOIST:   draw_glyph_letter(ctx, 'T', c, fg); break;
         case DEST_WEBHOOK:   draw_glyph_letter(ctx, 'H', c, fg); break;
         case DEST_NEXTCLOUD: draw_glyph_letter(ctx, 'C', c, fg); break;
+        case DEST_NEXTCLOUD_TASKS: draw_glyph_letter(ctx, 'C', c, fg); break;
         default:             draw_glyph_letter(ctx, '?', c, fg); break;
     }
 }
@@ -1312,9 +1324,12 @@ static void success_canvas_update(Layer *layer, GContext *ctx) {
         GRect(gx + tile + gap, chip_cy - chip_h / 2, ns.w + 4, chip_h),
         GTextOverflowModeFill, GTextAlignmentLeft, NULL);
 
-    // Transcript quote (dimmed, up to 2 lines)
-    graphics_context_set_text_color(ctx, GColorLightGray);
-    graphics_draw_text(ctx, s_success_quote, app_font(AF_FOOTER),
+    // Two-way webhook reply (if any) replaces the transcript quote — the
+    // endpoint talked back, so show what it said. Otherwise the dimmed quote.
+    bool has_reply = (s_success_dest == DEST_WEBHOOK && s_webhook_msg_buf[0]);
+    const char *footer = has_reply ? s_webhook_msg_buf : s_success_quote;
+    graphics_context_set_text_color(ctx, has_reply ? C_ON_SCREEN : GColorLightGray);
+    graphics_draw_text(ctx, footer, app_font(AF_FOOTER),
         GRect(8, h * 72 / 100 + y_shift + dumped_gap, w - 16, 40),
         GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
 }

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -60,6 +60,7 @@ function getEnabledDests(cfg) {
     if (cfg.ai_enabled)      d.push('ai');
     if (cfg.webhook_enabled)   d.push('webhook');
     if (cfg.nextcloud_enabled) d.push('nextcloud');
+    if (cfg.nextcloud_tasks_enabled) d.push('nextcloud_tasks');
     return d;
 }
 
@@ -207,6 +208,18 @@ function classifyIntent(text, enabled, cfg) {
         });
         getCustomKeywords(cfg, 'nextcloud').forEach(function(k) {
             if (t.indexOf(k) >= 0) scores['nextcloud'] += 2;
+        });
+    }
+
+    // Task signals — Nextcloud Tasks (CalDAV)
+    if (scores['nextcloud_tasks'] !== undefined) {
+        TASK_SIGNALS.forEach(function(p) { if (t.indexOf(p) >= 0) scores['nextcloud_tasks'] += 2; });
+        tw.forEach(function(w) { if (t.indexOf(w) >= 0) scores['nextcloud_tasks'] += 1; });
+        ['nextcloud task', 'nextcloud tasks', 'add to nextcloud tasks'].forEach(function(k) {
+            if (t.indexOf(k) >= 0) scores['nextcloud_tasks'] += 4;
+        });
+        getCustomKeywords(cfg, 'nextcloud_tasks').forEach(function(k) {
+            if (t.indexOf(k) >= 0) scores['nextcloud_tasks'] += 2;
         });
     }
 
@@ -721,7 +734,15 @@ function sendToWebhook(text, cfg, cb) {
     }
     if (token) xhr.setRequestHeader('Authorization', 'Bearer ' + token);
     xhr.onload = function() {
-        cb(this.status >= 200 && this.status < 300, 'webhook');
+        var isOk = this.status >= 200 && this.status < 300;
+        // Surface the webhook's response body to the watch when present, so the
+        // endpoint can reply back (e.g. confirmation text). Falls back to 'webhook'.
+        var data = 'webhook';
+        if (isOk && this.responseText) {
+            var rt = this.responseText.trim();
+            if (rt.length > 0) data = rt;
+        }
+        cb(isOk, data);
     };
     xhr.onerror = function() { cb(false, 'Network error'); };
     if (verb !== 'GET') {
@@ -809,7 +830,7 @@ function sendToNextcloud(text, cfg, cb) {
     var instance = (cfg.nextcloud_url || '').replace(/\/$/, '');
     var user     = cfg.nextcloud_user;
     var pass     = cfg.nextcloud_pass;
-    if (!instance || !user || !pass) { cb(false, 'Nextcloud not configured'); return; }
+    if (!instance || !user || !pass) { cb(false, 'Nextcloud Notes not configured'); return; }
 
     var body = {
         title:    text.substring(0, 80),
@@ -833,6 +854,99 @@ function sendToNextcloud(text, cfg, cb) {
     };
     xhr.onerror = function() { cb(false, 'Network error'); };
     xhr.send(JSON.stringify(body));
+}
+
+// ============================================================================
+// NEXTCLOUD TASKS  (CalDAV / VTODO)
+// ============================================================================
+
+// Pull the human-readable reason out of a Sabre/DAV XML error body, if present.
+function sabreError(body) {
+    if (!body) return '';
+    var m = body.match(/<s:message>([\s\S]*?)<\/s:message>/i) ||
+            body.match(/<s:exception>([\s\S]*?)<\/s:exception>/i);
+    return m ? m[1].replace(/^Sabre\\[\w\\]*\\/, '').trim() : '';
+}
+
+// Escape a string for an iCalendar TEXT value (RFC 5545 §3.3.11).
+function icalEscape(s) {
+    return String(s)
+        .replace(/\\/g, '\\\\')
+        .replace(/;/g, '\\;')
+        .replace(/,/g, '\\,')
+        .replace(/\r\n|\r|\n/g, '\\n');
+}
+
+function sendToNextcloudTasks(text, cfg, cb) {
+    var instance = (cfg.nextcloud_tasks_url || '').replace(/\/$/, '');
+    var user     = cfg.nextcloud_tasks_user;
+    var pass     = cfg.nextcloud_tasks_pass;
+    var list     = (cfg.nextcloud_tasks_list || 'personal').replace(/^\/|\/$/g, '');
+    if (!instance || !user || !pass) { cb(false, 'Nextcloud Tasks not configured'); return; }
+
+    function pad(n) { return n < 10 ? '0' + n : '' + n; }
+
+    var dueDate = extractDueDate(text);
+    var summary = dueDate ? stripDateTimeFromText(text) : text;
+
+    var dueLine = '';
+    if (dueDate) {
+        var ymd = dueDate.substring(0, 10).replace(/-/g, '');
+        var dueTime = extractTime(text);
+        dueLine = dueTime
+            ? 'DUE:' + ymd + 'T' + pad(dueTime.h) + pad(dueTime.m) + '00'
+            : 'DUE;VALUE=DATE:' + ymd;
+    }
+
+    var gp = guessPriority(text);
+    var prio = gp === 4 ? 1 : gp === 3 ? 3 : gp === 2 ? 5 : 0;
+
+    var now = new Date();
+    var dtstamp = now.getUTCFullYear() + pad(now.getUTCMonth() + 1) + pad(now.getUTCDate()) +
+                  'T' + pad(now.getUTCHours()) + pad(now.getUTCMinutes()) + pad(now.getUTCSeconds()) + 'Z';
+    var slug = 'braindump-' + Date.now() + '-' + Math.floor(Math.random() * 1000000);
+    var uid  = slug + '@pebble';
+
+    var lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Brain Dump//Pebble//EN',
+        'BEGIN:VTODO',
+        'UID:' + uid,
+        'DTSTAMP:' + dtstamp,
+        'SUMMARY:' + icalEscape(summary),
+        'STATUS:NEEDS-ACTION'
+    ];
+    if (prio > 0) lines.push('PRIORITY:' + prio);
+    if (dueLine)  lines.push(dueLine);
+    lines.push('END:VTODO');
+    lines.push('END:VCALENDAR');
+    var ics = lines.join('\r\n') + '\r\n';
+
+    var url = instance + '/remote.php/dav/calendars/' +
+              encodeURIComponent(user) + '/' + encodeURIComponent(list) + '/' + slug + '.ics';
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('PUT', url);
+    xhr.setRequestHeader('Authorization', 'Basic ' + btoa64(user + ':' + pass));
+    xhr.setRequestHeader('Content-Type', 'text/calendar; charset=utf-8');
+    xhr.onload = function() {
+        if (this.status >= 200 && this.status < 300) {
+            cb(true, 'nextcloud_tasks');
+        } else if (this.status === 401) {
+            cb(false, 'Invalid credentials');
+        } else if (this.status === 403) {
+            console.log('Nextcloud Tasks 403 body: ' + this.responseText);
+            var why = sabreError(this.responseText);
+            cb(false, why ? '403: ' + why : 'Forbidden: list "' + list + '" rejects tasks?');
+        } else if (this.status === 404) {
+            cb(false, 'List not found: ' + list);
+        } else {
+            cb(false, 'Error ' + this.status);
+        }
+    };
+    xhr.onerror = function() { cb(false, 'Network error'); };
+    xhr.send(ics);
 }
 
 // ============================================================================
@@ -971,7 +1085,7 @@ function stripDateTimeFromText(text) {
 // ROUTER
 // ============================================================================
 
-var DEST_INDEX = { tasks: 0, notion: 1, ai: 2, webhook: 3, local: 4, todoist: 5, nextcloud: 6 };
+var DEST_INDEX = { tasks: 0, notion: 1, ai: 2, webhook: 3, local: 4, todoist: 5, nextcloud: 6, nextcloud_tasks: 7 };
 
 function routeAndSend(text, isFollowup) {
     var cfg     = getConfig();
@@ -999,6 +1113,7 @@ function routeAndSend(text, isFollowup) {
     if (dest === 'ai' && !isFollowup && isTaskLike(text)) {
         if      (enabled.indexOf('tasks')   >= 0) dest = 'tasks';
         else if (enabled.indexOf('todoist') >= 0) dest = 'todoist';
+        else if (enabled.indexOf('nextcloud_tasks') >= 0) dest = 'nextcloud_tasks';
         else dest = 'local';
     }
 
@@ -1012,7 +1127,7 @@ function routeAndSend(text, isFollowup) {
     // Original text is still used for routing, due-date extraction, and AI context.
     var sendText = cleanNoteText(text);
 
-    var DEST_LABEL = { tasks: 'Tasks', notion: 'Notion', ai: 'AI', webhook: 'Webhook', local: 'Local', todoist: 'Todoist', nextcloud: 'Nextcloud' };
+    var DEST_LABEL = { tasks: 'Tasks', notion: 'Notion', ai: 'AI', webhook: 'Webhook', local: 'Local', todoist: 'Todoist', nextcloud: 'Nextcloud Notes', nextcloud_tasks: 'Nextcloud Tasks' };
 
     function onResult(ok, data) {
         if (!ok) {
@@ -1025,6 +1140,10 @@ function routeAndSend(text, isFollowup) {
         addHistory(sendText, di);
         if (dest === 'ai') {
             sendToWatch({ AI_RESPONSE: data, AI_RESPONSE_DONE: 1, DEST_USED: di });
+        } else if (dest === 'webhook' && data !== 'webhook') {
+            // Two-way webhook: surface the endpoint's response body on the watch.
+            console.log('Sending webhook response to watch: ' + data);
+            sendToWatch({ CONFIRM: 1, DEST_USED: di, WEBHOOK_MSG: ('' + data).substring(0, 100) });
         } else {
             var msg = { CONFIRM: 1, DEST_USED: di };
             if (data && typeof data === 'object' && data.taskId) {
@@ -1041,6 +1160,7 @@ function routeAndSend(text, isFollowup) {
         case 'webhook':   sendToWebhook   (sendText, cfg, onResult); break;
         case 'todoist':   sendToTodoist   (sendText, cfg, onResult); break;
         case 'nextcloud': sendToNextcloud (sendText, cfg, onResult); break;
+        case 'nextcloud_tasks': sendToNextcloudTasks(sendText, cfg, onResult); break;
         case 'local':     onResult(true, 'local'); break;  // saved on-watch from s_note_buf
         default:          sendToWatch({ CONFIRM: 2 });
     }
@@ -1080,6 +1200,7 @@ function computeDestMask(cfg) {
     if (enabled.indexOf('webhook')   >= 0) mask |= 8;
     if (enabled.indexOf('todoist')   >= 0) mask |= 32;
     if (enabled.indexOf('nextcloud') >= 0) mask |= 64;
+    if (enabled.indexOf('nextcloud_tasks') >= 0) mask |= 128;
     return mask;
 }
 
@@ -1150,11 +1271,12 @@ Pebble.addEventListener('appmessage', function(e) {
             if (dest2 === 'ai' && isTaskLike(p.NOTE_TEXT)) {
                 if      (enabled2.indexOf('tasks')   >= 0) dest2 = 'tasks';
                 else if (enabled2.indexOf('todoist') >= 0) dest2 = 'todoist';
+                else if (enabled2.indexOf('nextcloud_tasks') >= 0) dest2 = 'nextcloud_tasks';
                 else dest2 = 'local';
             }
             var msg2 = { ROUTING_DONE: DEST_INDEX[dest2] !== undefined ? DEST_INDEX[dest2] : 4 };
             // Surface an extracted due date/time for task destinations.
-            if (dest2 === 'tasks' || dest2 === 'todoist') {
+            if (dest2 === 'tasks' || dest2 === 'todoist' || dest2 === 'nextcloud_tasks') {
                 var due = formatDueLabel(p.NOTE_TEXT);
                 if (due) msg2.DUE_LABEL = due;
             }
@@ -1248,6 +1370,7 @@ Pebble.addEventListener('showConfiguration', function() {
     '<option value="notion"  ' + sel(cfg.default_dest,'notion')  + '>Notion</option>' +
     '<option value="ai"      ' + sel(cfg.default_dest,'ai')      + '>AI Agent</option>' +
     '<option value="nextcloud" ' + sel(cfg.default_dest,'nextcloud') + '>Nextcloud Notes</option>' +
+    '<option value="nextcloud_tasks" ' + sel(cfg.default_dest,'nextcloud_tasks') + '>Nextcloud Tasks</option>' +
     '<option value="webhook"   ' + sel(cfg.default_dest,'webhook')   + '>Webhook</option>' +
     '</select></label>' +
     '</div>' +
@@ -1329,6 +1452,21 @@ Pebble.addEventListener('showConfiguration', function() {
     'Category (optional):<input type="text" id="nextcloud_category" value=\'' + esc(cfg.nextcloud_category) + '\' placeholder="Brain Dump">' +
     'Routing keywords (comma-separated, added to defaults):<input type="text" id="nextcloud_keywords"' +
     ' value=\'' + esc(cfg.nextcloud_keywords) + '\' placeholder="nextcloud, cloud note, ...">' +
+    '</div></div>' +
+
+    // ---- Nextcloud Tasks (CalDAV) ----
+    '<div class="section">' +
+    '<label class="toggle-label"><input type="checkbox" id="nextcloud_tasks_enabled" ' + chk(cfg.nextcloud_tasks_enabled) + '>' +
+    ' Nextcloud Tasks</label>' +
+    '<div class="fields">' +
+    'Instance URL:<input type="text" id="nextcloud_tasks_url" value=\'' + esc(cfg.nextcloud_tasks_url) + '\' placeholder="https://cloud.example.com">' +
+    'Username:<input type="text" id="nextcloud_tasks_user" value=\'' + esc(cfg.nextcloud_tasks_user) + '\'>' +
+    'App password:<input type="password" id="nextcloud_tasks_pass" value=\'' + esc(cfg.nextcloud_tasks_pass) + '\'>' +
+    '<p class="note">Generate an App Password in Nextcloud: Settings → Security → App passwords. May be the same instance as Nextcloud Notes.</p>' +
+    'Task list (CalDAV name):<input type="text" id="nextcloud_tasks_list" value=\'' + esc(cfg.nextcloud_tasks_list) + '\' placeholder="personal">' +
+    '<p class="note">The list\'s internal name, not its display title. Default list is usually "personal". Find it in the Tasks app URL: …/apps/tasks/#/calendars/<b>NAME</b></p>' +
+    'Routing keywords (comma-separated, added to defaults):<input type="text" id="nextcloud_tasks_keywords"' +
+    ' value=\'' + esc(cfg.nextcloud_tasks_keywords) + '\' placeholder="nextcloud task, todo cloud, ...">' +
     '</div></div>' +
 
     // ---- AI Agent ----
@@ -1544,6 +1682,12 @@ Pebble.addEventListener('showConfiguration', function() {
     'nextcloud_pass:document.getElementById("nextcloud_pass").value.trim(),' +
     'nextcloud_category:document.getElementById("nextcloud_category").value.trim(),' +
     'nextcloud_keywords:document.getElementById("nextcloud_keywords").value.trim(),' +
+    'nextcloud_tasks_enabled:document.getElementById("nextcloud_tasks_enabled").checked,' +
+    'nextcloud_tasks_url:document.getElementById("nextcloud_tasks_url").value.trim(),' +
+    'nextcloud_tasks_user:document.getElementById("nextcloud_tasks_user").value.trim(),' +
+    'nextcloud_tasks_pass:document.getElementById("nextcloud_tasks_pass").value.trim(),' +
+    'nextcloud_tasks_list:document.getElementById("nextcloud_tasks_list").value.trim(),' +
+    'nextcloud_tasks_keywords:document.getElementById("nextcloud_tasks_keywords").value.trim(),' +
     'ai_enabled:document.getElementById("ai_enabled").checked,' +
     'ai_preset:document.getElementById("ai_preset").value,' +
     'ai_url:document.getElementById("ai_url").value.trim(),' +


### PR DESCRIPTION
## Summary

Adds **Nextcloud Tasks** as a first-class task-manager destination in Brain Dump,
and makes the existing **custom webhook** two-way by surfacing its response on the watch.

## What's new

### Nextcloud Tasks (CalDAV / VTODO)
- New destination (index 7), separate from the existing **Nextcloud Notes** integration,
  with its own credentials, list name, and routing keywords.
- Creates tasks via `PUT` of an iCalendar `VTODO` to
  `/remote.php/dav/calendars/<user>/<list>/<uid>.ics` (Basic auth / app password).
- Reuses the shared NLP helpers: due date → `DUE`, time → date-time `DUE`,
  priority → VTODO `PRIORITY` (`guessPriority` 1–4 mapped to 1/3/5).
- Note text is escaped per RFC 5545 (`icalEscape`) to prevent calendar-property injection.
- Friendly errors: 401 / 403 (parses the Sabre/DAV `<s:message>`) / 404 / generic.

### Webhook responses
- `sendToWebhook` now returns the response body when present, and the watch displays it
  under the status line via a new `WEBHOOK_MSG` app message — the webhook becomes two-way.
- Credit: this feature is ported from **[@zdschade](https://github.com/zdschade)**'s
  [yet-another-brain-dump](https://github.com/zdschade/yet-another-brain-dump) fork
  ("Added support for webhook response").

## Fixes
- **Dest-mask bug:** `webviewclosed` recomputed the destination mask but dropped the
  Todoist and Nextcloud bits, so those toggles were lost after saving settings.
  Both the `ready` and `webviewclosed` handlers now share one `computeDestMask()` helper.

## Repo / docs
- Restructured to an app-only layout (Brain Dump at the repo root; dropped the unused
  watchface-skill scaffolding, samples, and tutorials inherited from upstream).
- Added a new `README.md` describing the app and crediting the upstream fork.

## Testing
- `pebble build` succeeds for all platforms (aplite/basalt/chalk/diorite/emery/gabbro).
- `node test/extractTime.test.js` → 140 passed, 0 failed.
- `node --check` on `src/pkjs/index.js` passes.

Ported from https://github.com/adrienthiery/pebble-watchface-agent-skill/pull/4 

cc @julpel8