### PR TITLE
Retry failed sends via a phone-side queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "DUE_LABEL",
       "EXTERNAL_ID",
       "COMPLETE_TASK",
-      "WEBHOOK_MSG"
+      "WEBHOOK_MSG",
+      "QUEUE_RETRY"
     ],
     "resources": {
       "media": [

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -692,6 +692,15 @@ static void appmsg_complete_task(const char *external_id) {
     app_message_outbox_send();
 }
 
+// Tell the phone the user picked "Retry later" on the send-failed fallback, so
+// it queues the note that just failed for a later retry.
+static void appmsg_queue_retry(void) {
+    DictionaryIterator *iter;
+    if (app_message_outbox_begin(&iter) != APP_MSG_OK) return;
+    dict_write_int8(iter, MESSAGE_KEY_QUEUE_RETRY, 1);
+    app_message_outbox_send();
+}
+
 static void route_note(bool is_followup) {
     if (!is_phone_connected()) {
         if (is_followup) {
@@ -1387,8 +1396,10 @@ static void success_window_unload(Window *window) {
 }
 
 // ============================================================================
-// SEND-FAILED FALLBACK — a cloud send failed; offer to keep the note locally
-// so it isn't lost. SELECT saves it as a local reminder; BACK discards.
+// SEND-FAILED FALLBACK — a cloud send failed; offer two ways to keep the note
+// so it isn't lost. UP asks the phone to retry it later (queued phone-side);
+// SELECT saves it as an on-watch local reminder; BACK discards. The two are
+// mutually exclusive, so the note is never both queued and saved locally.
 // ============================================================================
 
 static void fallback_canvas_update(Layer *layer, GContext *ctx) {
@@ -1407,9 +1418,11 @@ static void fallback_canvas_update(Layer *layer, GContext *ctx) {
 #endif
     draw_status_divider(ctx, b);
 
-    // Bottom hint "→ Local note?", positioned like the review screen's target.
-    int hint_h = app_font_h(AF_HEADER);
-    int hint_y = b.size.h - CONFIRM_BOTTOM_PAD - hint_h;
+    // Two stacked choice hints at the bottom, in button order (UP then SELECT),
+    // mirroring the two action-bar icons. BACK discards and needs no label.
+    int hint_h = app_font_h(AF_FOOTER);
+    int hint2_y = b.size.h - CONFIRM_BOTTOM_PAD - hint_h;
+    int hint1_y = hint2_y - hint_h;
 
     // Error message, prefixed. HEADER size — bigger than a caption but small
     // enough that a typical error fits without being cut.
@@ -1418,18 +1431,29 @@ static void fallback_canvas_update(Layer *layer, GContext *ctx) {
     int content_top = STATUS_H + 4;
     graphics_context_set_text_color(ctx, C_ON_SCREEN);
     graphics_draw_text(ctx, disp, app_font(AF_HEADER),
-        GRect(4, content_top, content_w, hint_y - 6 - content_top),
+        GRect(4, content_top, content_w, hint1_y - 6 - content_top),
         GTextOverflowModeWordWrap, GTextAlignmentLeft, NULL);
 
     graphics_context_set_text_color(ctx, C_ON_SCREEN);
-    graphics_draw_text(ctx, "\xe2\x86\x92 Local note?", app_font(AF_HEADER),
-        GRect(4, hint_y, content_w, hint_h + 2),
+    graphics_draw_text(ctx, "Retry later", app_font(AF_FOOTER),
+        GRect(4, hint1_y, content_w, hint_h + 2),
+        GTextOverflowModeFill, GTextAlignmentLeft, NULL);
+    graphics_draw_text(ctx, "Save local", app_font(AF_FOOTER),
+        GRect(4, hint2_y, content_w, hint_h + 2),
         GTextOverflowModeFill, GTextAlignmentLeft, NULL);
 
-    // Action bar — checkmark = save (SELECT); back dismisses.
+    // Action bar — redo = retry later (UP), local-note glyph = save (SELECT);
+    // back dismisses. Redo icon reused from the dictation confirm screen.
     draw_action_bar(ctx, b);
     int ax = action_bar_icon_x(b);
-    draw_icon_checkmark(ctx, GPoint(ax, btn_select_y(b)), ACTION_ICON_COLOR);
+    draw_icon_redo_review(ctx, GPoint(ax, btn_up_y(b)),     ACTION_ICON_COLOR);
+    draw_glyph_lines     (ctx, GPoint(ax, btn_select_y(b)), ACTION_ICON_COLOR);
+}
+
+static void fallback_retry_click(ClickRecognizerRef rec, void *ctx) {
+    window_stack_pop(true);
+    appmsg_queue_retry();
+    set_status("Queued for retry");
 }
 
 static void fallback_save_click(ClickRecognizerRef rec, void *ctx) {
@@ -1445,6 +1469,7 @@ static void fallback_dismiss_click(ClickRecognizerRef rec, void *ctx) {
 }
 
 static void fallback_click_config(void *ctx) {
+    window_single_click_subscribe(BUTTON_ID_UP,     fallback_retry_click);
     window_single_click_subscribe(BUTTON_ID_SELECT, fallback_save_click);
     window_single_click_subscribe(BUTTON_ID_BACK,   fallback_dismiss_click);
 }

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -79,15 +79,18 @@ function enqueueFailed(text, dest, ts) {
     saveQueue(q);
 }
 
-// Advance the queue after a delivery attempt on its head item. On success the
-// head is removed; on failure its retry counter grows and it is dropped once it
-// exceeds the cap (so a permanently failing note can't block the rest forever).
-// Pure — the caller reads/writes storage — so it stays easy to unit-test.
+// Advance the queue after a delivery attempt on its head item. The head is
+// shifted off in all cases; on failure its retry counter grows and it is
+// re-appended at the tail unless it has exhausted the cap (then it is dropped).
+// Re-appending means a permanently failing item cycles to the back instead of
+// head-blocking the rest of the queue. Pure — the caller reads/writes storage —
+// so it stays easy to unit-test.
 function queueAfterResult(q, ok) {
     if (!q.length) return q;
-    if (ok) { q.shift(); return q; }
-    q[0].tries = (q[0].tries || 0) + 1;
-    if (q[0].tries >= MAX_QUEUE_RETRIES) q.shift();
+    var item = q.shift();
+    if (ok) return q;
+    item.tries = (item.tries || 0) + 1;
+    if (item.tries < MAX_QUEUE_RETRIES) q.push(item);
     return q;
 }
 
@@ -1419,28 +1422,52 @@ function routeAndSend(text, isFollowup) {
 }
 
 // Try to deliver queued notes oldest-first. Runs on the PebbleKit JS 'ready'
-// event and after any successful send. Serialized via s_flushing; stops on the
-// first failure so a still-down network doesn't burn every item's retries in
-// one pass — the next trigger picks up where this left off.
+// event and after any successful send. Serialized via s_flushing.
+//
+// Failures are tracked per-destination, not globally: when a send to a
+// destination fails, that destination is marked down for the rest of this pass
+// and its items are skipped, but items bound for other destinations still get a
+// try. So a webhook being down no longer blocks queued Notion notes. The pass
+// ends only once every remaining item is bound for a destination that already
+// failed this pass; the next trigger starts a fresh pass.
 var s_flushing = false;
 function flushQueue() {
     if (s_flushing) return;
-    var q = getQueue();
-    if (q.length === 0) return;
+    if (getQueue().length === 0) return;
     s_flushing = true;
-    var cfg  = getConfig();
+    flushStep(getConfig(), {}, 0);
+}
+
+// One step of a flush pass. `down` is the set of destinations that have already
+// failed this pass. `rotated` counts how many heads we have skipped in a row
+// without a real send attempt — once it reaches the queue length, every
+// remaining item is bound for a down destination and the pass is over.
+function flushStep(cfg, down, rotated) {
+    var q = getQueue();
+    if (q.length === 0) { s_flushing = false; return; }
+
+    // Head is bound for a destination already known down this pass: rotate it to
+    // the tail (no retry charged) and move on to the next distinct destination.
+    if (down[q[0].dest]) {
+        if (rotated >= q.length) { s_flushing = false; return; }
+        q.push(q.shift());
+        saveQueue(q);
+        flushStep(cfg, down, rotated + 1);
+        return;
+    }
+
     var item = q[0];
     sendToDest(item.dest, item.text, cfg, function(ok, data) {
         saveQueue(queueAfterResult(getQueue(), ok));
-        s_flushing = false;
         if (ok) {
             var di = DEST_INDEX[item.dest] !== undefined ? DEST_INDEX[item.dest] : 4;
             addHistory(item.text, di);
             console.log('Retried queued note → ' + item.dest);
-            flushQueue();   // network is up — keep draining the backlog
         } else {
+            down[item.dest] = 1;   // this destination is down — skip it this pass
             console.log('Queued note still failing (' + item.dest + '): ' + data);
         }
+        flushStep(cfg, down, 0);   // real attempt made — reset the skip counter
     });
 }
 

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -4,6 +4,12 @@
 
 var KEY_CONFIG  = 'brain_dump_cfg_v1';
 var KEY_HISTORY = 'brain_dump_hist_v1';
+var KEY_QUEUE   = 'brain_dump_queue_v1';
+
+// Retry queue bounds: drop an item after this many failed attempts, and never
+// let the queue grow past this many entries (oldest dropped first).
+var MAX_QUEUE_RETRIES = 5;
+var MAX_QUEUE_LEN     = 50;
 
 var TASKS_CLIENT_ID = '122599459809-1egpb0mrc97lpeh6fshnfv1i1drnvnkd.apps.googleusercontent.com';
 // secrets.js is gitignored; secrets.example.js is the committed placeholder.
@@ -46,6 +52,43 @@ function addHistory(text, dest) {
                 ts: Math.floor(Date.now() / 1000) });
     if (h.length > 50) h = h.slice(0, 50);
     try { localStorage.setItem(KEY_HISTORY, JSON.stringify(h)); } catch(e) {}
+}
+
+// ============================================================================
+// RETRY QUEUE  (failed sends, persisted phone-side)
+// ============================================================================
+// When a note is transcribed but delivery to its destination fails (network
+// drop, API error, rate limit), it is queued here instead of dead-ending in
+// the on-watch fallback. The queue is FIFO and flushed on 'ready' and after
+// any successful send. Entries: { text, dest, ts, tries }.
+
+function getQueue() {
+    try { var r = localStorage.getItem(KEY_QUEUE); return r ? JSON.parse(r) : []; }
+    catch(e) { return []; }
+}
+function saveQueue(q) {
+    try { localStorage.setItem(KEY_QUEUE, JSON.stringify(q)); } catch(e) {}
+}
+
+// Append a failed send, preserving its original dictation timestamp. Oldest
+// entries are dropped once the queue is full so it can't grow without bound.
+function enqueueFailed(text, dest, ts) {
+    var q = getQueue();
+    q.push({ text: text, dest: dest, ts: ts, tries: 0 });
+    if (q.length > MAX_QUEUE_LEN) q = q.slice(q.length - MAX_QUEUE_LEN);
+    saveQueue(q);
+}
+
+// Advance the queue after a delivery attempt on its head item. On success the
+// head is removed; on failure its retry counter grows and it is dropped once it
+// exceeds the cap (so a permanently failing note can't block the rest forever).
+// Pure — the caller reads/writes storage — so it stays easy to unit-test.
+function queueAfterResult(q, ok) {
+    if (!q.length) return q;
+    if (ok) { q.shift(); return q; }
+    q[0].tries = (q[0].tries || 0) + 1;
+    if (q[0].tries >= MAX_QUEUE_RETRIES) q.shift();
+    return q;
 }
 
 // ============================================================================
@@ -1270,6 +1313,25 @@ function stripDateTimeFromText(text) {
 
 var DEST_INDEX = { tasks: 0, notion: 1, ai: 2, webhook: 3, local: 4, todoist: 5, nextcloud: 6, nextcloud_tasks: 7 };
 
+// Destinations whose delivery is a one-shot HTTP send that can be safely
+// retried later. 'ai' (a live conversation) and 'local' (saved on-watch) are
+// intentionally excluded from the retry queue.
+var QUEUEABLE_DESTS = { tasks: 1, notion: 1, webhook: 1, todoist: 1, nextcloud: 1, nextcloud_tasks: 1 };
+
+// Dispatch a note to a single cloud destination. Shared by the live router and
+// the retry-queue flush so both take exactly the same delivery path.
+function sendToDest(dest, text, cfg, cb) {
+    switch (dest) {
+        case 'tasks':           sendToTasks         (text, cfg, cb); break;
+        case 'notion':          sendToNotion        (text, cfg, cb); break;
+        case 'webhook':         sendToWebhook       (text, cfg, cb); break;
+        case 'todoist':         sendToTodoist       (text, cfg, cb); break;
+        case 'nextcloud':       sendToNextcloud     (text, cfg, cb); break;
+        case 'nextcloud_tasks': sendToNextcloudTasks(text, cfg, cb); break;
+        default:                cb(false, 'Unknown destination');
+    }
+}
+
 // Single source of truth for destination selection, used by BOTH the confirm
 // preview (classify-only) and the real send — so the "→ X" shown on the review
 // screen is always where the note actually goes. Honours routing_auto: when it
@@ -1295,6 +1357,9 @@ function pickDest(text, enabled, cfg, isFollowup) {
 function routeAndSend(text, isFollowup) {
     var cfg     = getConfig();
     var enabled = getEnabledDests(cfg);
+    // Captured once so a failed send keeps the note's original dictation time
+    // when it is queued for retry, matching how addHistory stamps notes.
+    var ts = Math.floor(Date.now() / 1000);
 
     // If no cloud services are configured, go local.
     if (enabled.length === 0 && !isFollowup) {
@@ -1320,12 +1385,17 @@ function routeAndSend(text, isFollowup) {
     function onResult(ok, data) {
         if (!ok) {
             console.log('Send failed: ' + data);
+            // Queue retryable cloud sends so the note isn't lost to a transient
+            // network/API failure; the watch still offers its local fallback.
+            if (QUEUEABLE_DESTS[dest]) enqueueFailed(sendText, dest, ts);
             var label = DEST_LABEL[dest] || dest;
             var msg = (label + ': ' + (data || 'Unknown error')).substring(0, 45);
             sendToWatch({ CONFIRM: 2, ERROR_MSG: msg });
             return;
         }
         addHistory(sendText, di);
+        // A live send just succeeded → the network is up, so drain any backlog.
+        flushQueue();
         if (dest === 'ai') {
             sendToWatch({ AI_RESPONSE: data, AI_RESPONSE_DONE: 1, DEST_USED: di });
         } else if (dest === 'webhook' && data !== 'webhook') {
@@ -1342,16 +1412,36 @@ function routeAndSend(text, isFollowup) {
     }
 
     switch (dest) {
-        case 'tasks':     sendToTasks     (sendText, cfg, onResult); break;
-        case 'notion':    sendToNotion    (sendText, cfg, onResult); break;
-        case 'ai':        sendToAI        (sendText, isFollowup, cfg, onResult); break;
-        case 'webhook':   sendToWebhook   (sendText, cfg, onResult); break;
-        case 'todoist':   sendToTodoist   (sendText, cfg, onResult); break;
-        case 'nextcloud': sendToNextcloud (sendText, cfg, onResult); break;
-        case 'nextcloud_tasks': sendToNextcloudTasks(sendText, cfg, onResult); break;
-        case 'local':     onResult(true, 'local'); break;  // saved on-watch from s_note_buf
-        default:          sendToWatch({ CONFIRM: 2 });
+        case 'ai':    sendToAI(sendText, isFollowup, cfg, onResult); break;
+        case 'local': onResult(true, 'local'); break;  // saved on-watch from s_note_buf
+        default:      sendToDest(dest, sendText, cfg, onResult);
     }
+}
+
+// Try to deliver queued notes oldest-first. Runs on the PebbleKit JS 'ready'
+// event and after any successful send. Serialized via s_flushing; stops on the
+// first failure so a still-down network doesn't burn every item's retries in
+// one pass — the next trigger picks up where this left off.
+var s_flushing = false;
+function flushQueue() {
+    if (s_flushing) return;
+    var q = getQueue();
+    if (q.length === 0) return;
+    s_flushing = true;
+    var cfg  = getConfig();
+    var item = q[0];
+    sendToDest(item.dest, item.text, cfg, function(ok, data) {
+        saveQueue(queueAfterResult(getQueue(), ok));
+        s_flushing = false;
+        if (ok) {
+            var di = DEST_INDEX[item.dest] !== undefined ? DEST_INDEX[item.dest] : 4;
+            addHistory(item.text, di);
+            console.log('Retried queued note → ' + item.dest);
+            flushQueue();   // network is up — keep draining the backlog
+        } else {
+            console.log('Queued note still failing (' + item.dest + '): ' + data);
+        }
+    });
 }
 
 // AppMessage allows only one message in flight; a second sendAppMessage before
@@ -1400,6 +1490,9 @@ Pebble.addEventListener('ready', function() {
     console.log('Brain Dump JS ready');
     var cfg     = getConfig();
     sendToWatch({ DEST_MASK: computeDestMask(cfg) });
+
+    // Retry any sends that failed while the phone was offline / the API was down.
+    flushQueue();
 
     // Proactively refresh Google access token so it's always fresh before use.
     // Access tokens expire after 1 hour; refreshing on every connect keeps them valid.

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -9,7 +9,7 @@ var KEY_QUEUE   = 'brain_dump_queue_v1';
 // Retry queue bounds: drop an item after this many failed attempts, and never
 // let the queue grow past this many entries (oldest dropped first).
 var MAX_QUEUE_RETRIES = 5;
-var MAX_QUEUE_LEN     = 50;
+var MAX_QUEUE_LEN     = 10;
 
 var TASKS_CLIENT_ID = '122599459809-1egpb0mrc97lpeh6fshnfv1i1drnvnkd.apps.googleusercontent.com';
 // secrets.js is gitignored; secrets.example.js is the committed placeholder.

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -25,6 +25,9 @@ var DEFAULT_SYSTEM_PROMPT =
 var s_ai_messages  = [];
 var s_last_note    = '';
 var s_clock_24h    = false;   // updated from watch on each note
+// The last failed cloud send, held until the watch reports the user's fallback
+// choice. Queued on "Retry later" (QUEUE_RETRY); dropped otherwise. { text, dest, ts }.
+var s_pending_retry = null;
 
 // ============================================================================
 // CONFIG HELPERS
@@ -1388,9 +1391,14 @@ function routeAndSend(text, isFollowup) {
     function onResult(ok, data) {
         if (!ok) {
             console.log('Send failed: ' + data);
-            // Queue retryable cloud sends so the note isn't lost to a transient
-            // network/API failure; the watch still offers its local fallback.
-            if (QUEUEABLE_DESTS[dest]) enqueueFailed(sendText, dest, ts);
+            // Don't auto-queue. Remember this failed send so the watch's fallback
+            // screen can decide: on "Retry later" (QUEUE_RETRY) the phone queues
+            // it; on "Save to local" the watch keeps it on-watch. Making the two
+            // mutually exclusive avoids the duplicate note the old auto-queue +
+            // local-fallback overlap could produce (#4).
+            s_pending_retry = QUEUEABLE_DESTS[dest]
+                ? { text: sendText, dest: dest, ts: ts }
+                : null;
             var label = DEST_LABEL[dest] || dest;
             var msg = (label + ': ' + (data || 'Unknown error')).substring(0, 45);
             sendToWatch({ CONFIRM: 2, ERROR_MSG: msg });
@@ -1591,6 +1599,16 @@ Pebble.addEventListener('appmessage', function(e) {
     if (p.CLEAR_CONTEXT) {
         s_ai_messages = [];
         console.log('AI context cleared');
+    }
+
+    // User chose "Retry later" on the send-failed fallback screen: queue the
+    // note that just failed so it retries on the next 'ready' or successful send.
+    if (p.QUEUE_RETRY) {
+        if (s_pending_retry) {
+            enqueueFailed(s_pending_retry.text, s_pending_retry.dest, s_pending_retry.ts);
+            console.log('Queued for retry → ' + s_pending_retry.dest);
+            s_pending_retry = null;
+        }
     }
 
     if (p.COMPLETE_TASK && p.EXTERNAL_ID) {

--- a/test/offlineQueue.test.js
+++ b/test/offlineQueue.test.js
@@ -32,9 +32,10 @@ function enqueueFailed(text, dest, ts) {
 }
 function queueAfterResult(q, ok) {
     if (!q.length) return q;
-    if (ok) { q.shift(); return q; }
-    q[0].tries = (q[0].tries || 0) + 1;
-    if (q[0].tries >= MAX_QUEUE_RETRIES) q.shift();
+    var item = q.shift();
+    if (ok) return q;
+    item.tries = (item.tries || 0) + 1;
+    if (item.tries < MAX_QUEUE_RETRIES) q.push(item);
     return q;
 }
 
@@ -103,53 +104,93 @@ check('empty queue is left alone',
 
 var q = [{ text: 'a', tries: 0 }, { text: 'b', tries: 0 }];
 q = queueAfterResult(q, false);
-check('failure increments the head tries', q[0].tries, 1);
-check('failure keeps the head in place (order preserved)',
-    q.map(function(e) { return e.text; }).join(','), 'a,b');
+check('failure moves the head to the tail (b is now next up)',
+    q.map(function(e) { return e.text; }).join(','), 'b,a');
+check('failure increments tries on the re-appended item',
+    q[q.length - 1].tries, 1);
+check('a re-appended item keeps its text', q[q.length - 1].text, 'a');
 
 section('queueAfterResult — retry cap');
 
-var poison = [{ text: 'bad', tries: 0 }, { text: 'good', tries: 0 }];
-for (var k = 0; k < MAX_QUEUE_RETRIES; k++) poison = queueAfterResult(poison, false);
-check('a permanently failing head is dropped after the cap',
-    poison.map(function(e) { return e.text; }).join(','), 'good');
+// A permanently failing item cycles to the tail each time; it is dropped only
+// once it has used up MAX_QUEUE_RETRIES attempts.
+var poison = [{ text: 'bad', tries: 0 }];
+for (var k = 0; k < MAX_QUEUE_RETRIES - 1; k++) poison = queueAfterResult(poison, false);
+check('survives up to the cap (still queued, cycling)', poison.length, 1);
+check('retry count reaches cap - 1 before the last attempt',
+    poison[0].tries, MAX_QUEUE_RETRIES - 1);
+poison = queueAfterResult(poison, false);
+check('dropped once it exhausts MAX_QUEUE_RETRIES attempts', poison.length, 0);
 
 // ============================================================
 // End-to-end drain simulation (mirrors flushQueue control flow)
 // ============================================================
 
-section('drain simulation — outage then recovery, FIFO preserved');
+section('drain simulation — per-destination failure isolation');
 
-reset();
-enqueueFailed('note-1', 'notion',  10);
-enqueueFailed('note-2', 'todoist', 11);
-enqueueFailed('note-3', 'webhook', 12);
-
-var delivered = [];
-
-// One flush pass over the head, honouring the "stop on first failure" rule.
-// Returns true when the head was delivered (so the caller keeps draining).
-function flushOnce(online) {
-    var cur = getQueue();
-    if (!cur.length) return false;
-    var head = cur[0];
-    var ok = online;
-    if (ok) delivered.push(head.text);
-    saveQueue(queueAfterResult(getQueue(), ok));
-    return ok;
+// Faithful synchronous mirror of flushStep() in index.js. `downDests` is the
+// set of destinations that are unreachable for this simulated pass. Returns the
+// list of note texts delivered during the pass, in the order they went out.
+function drainPass(downDests) {
+    var delivered = [];
+    var down = {};        // destinations found down during this pass
+    var rotated = 0;      // consecutive head-skips without a real attempt
+    while (true) {
+        var cur = getQueue();
+        if (cur.length === 0) break;
+        if (down[cur[0].dest]) {
+            // Head bound for an already-down destination: rotate past it. When a
+            // full lap yields no attemptable item, every remaining dest is down.
+            if (rotated >= cur.length) break;
+            cur.push(cur.shift());
+            saveQueue(cur);
+            rotated++;
+            continue;
+        }
+        var item = cur[0];
+        var ok = !downDests[item.dest];
+        saveQueue(queueAfterResult(getQueue(), ok));
+        if (ok) delivered.push(item.text);
+        else    down[item.dest] = 1;
+        rotated = 0;
+    }
+    return delivered;
 }
 
-// Network down: one trigger fires; head fails, draining stops.
-flushOnce(false);
-check('nothing delivered while offline', delivered.join(','), '');
-check('head retry recorded, queue intact', getQueue()[0].tries, 1);
-check('order unchanged during outage',
-    getQueue().map(function(e) { return e.text; }).join(','), 'note-1,note-2,note-3');
+// One destination down must not block notes bound for a healthy one.
+reset();
+enqueueFailed('w-1', 'webhook', 10);
+enqueueFailed('n-1', 'notion',  11);
+enqueueFailed('w-2', 'webhook', 12);
+enqueueFailed('n-2', 'notion',  13);
 
-// Network back: drain until the queue empties or the head fails.
-while (flushOnce(true)) { /* keep draining */ }
-check('all notes delivered in original order once online',
-    delivered.join(','), 'note-1,note-2,note-3');
+var out = drainPass({ webhook: 1 }).sort().join(',');
+check('notes for a healthy destination deliver despite another being down',
+    out, 'n-1,n-2');
+check('notes for the down destination stay queued',
+    getQueue().map(function(e) { return e.text; }).sort().join(','), 'w-1,w-2');
+check('a down destination is charged only one retry per pass (skip, not spin)',
+    getQueue().reduce(function(s, e) { return s + (e.tries || 0); }, 0), 1);
+
+section('drain simulation — outage then full recovery');
+
+reset();
+enqueueFailed('note-1', 'notion', 20);
+enqueueFailed('note-2', 'notion', 21);
+enqueueFailed('note-3', 'notion', 22);
+
+// Offline: notion is down, so the first item is tried once and the rest are
+// skipped for the pass — nothing delivered, retries not burned across the board.
+var off = drainPass({ notion: 1 });
+check('nothing delivered while offline', off.join(','), '');
+check('only one retry charged during the outage pass',
+    getQueue().reduce(function(s, e) { return s + (e.tries || 0); }, 0), 1);
+check('all three notes still queued', getQueue().length, 3);
+
+// Back online: the whole backlog drains (rotation may reorder a retried head).
+var on = drainPass({});
+check('all notes delivered once back online', on.slice().sort().join(','),
+    'note-1,note-2,note-3');
 check('queue is empty after a full drain', getQueue().length, 0);
 
 // ============================================================

--- a/test/offlineQueue.test.js
+++ b/test/offlineQueue.test.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 var MAX_QUEUE_RETRIES = 5;
-var MAX_QUEUE_LEN     = 50;
+var MAX_QUEUE_LEN     = 10;
 
 // Minimal localStorage stand-in (the pkjs runtime provides the real one).
 var _store = {};

--- a/test/offlineQueue.test.js
+++ b/test/offlineQueue.test.js
@@ -1,0 +1,160 @@
+// Unit tests for the failed-send retry queue (Brain Dump pkjs)
+// Run: node test/offlineQueue.test.js
+
+// ============================================================
+// Functions under test — keep in sync with src/pkjs/index.js
+// ============================================================
+
+var MAX_QUEUE_RETRIES = 5;
+var MAX_QUEUE_LEN     = 50;
+
+// Minimal localStorage stand-in (the pkjs runtime provides the real one).
+var _store = {};
+var localStorage = {
+    getItem: function(k) { return _store.hasOwnProperty(k) ? _store[k] : null; },
+    setItem: function(k, v) { _store[k] = String(v); },
+    removeItem: function(k) { delete _store[k]; }
+};
+var KEY_QUEUE = 'brain_dump_queue_v1';
+
+function getQueue() {
+    try { var r = localStorage.getItem(KEY_QUEUE); return r ? JSON.parse(r) : []; }
+    catch(e) { return []; }
+}
+function saveQueue(q) {
+    try { localStorage.setItem(KEY_QUEUE, JSON.stringify(q)); } catch(e) {}
+}
+function enqueueFailed(text, dest, ts) {
+    var q = getQueue();
+    q.push({ text: text, dest: dest, ts: ts, tries: 0 });
+    if (q.length > MAX_QUEUE_LEN) q = q.slice(q.length - MAX_QUEUE_LEN);
+    saveQueue(q);
+}
+function queueAfterResult(q, ok) {
+    if (!q.length) return q;
+    if (ok) { q.shift(); return q; }
+    q[0].tries = (q[0].tries || 0) + 1;
+    if (q[0].tries >= MAX_QUEUE_RETRIES) q.shift();
+    return q;
+}
+
+// ============================================================
+// Test harness (same style as the other pkjs tests)
+// ============================================================
+
+var passed = 0;
+var failed = 0;
+
+function check(label, got, expected) {
+    if (got === expected) {
+        passed++;
+        process.stdout.write('  ✓ ' + label + '\n');
+    } else {
+        failed++;
+        process.stdout.write('  ✗ ' + label + '\n      got: ' + got + '\n expected: ' + expected + '\n');
+    }
+}
+function checkObject(label, got, expected) {
+    check(label, JSON.stringify(got), JSON.stringify(expected));
+}
+function section(name) {
+    process.stdout.write('\n' + name + '\n');
+}
+function reset() { _store = {}; }
+
+// ============================================================
+// enqueueFailed — order + bounds
+// ============================================================
+
+section('enqueueFailed — order and bounds');
+
+reset();
+enqueueFailed('first',  'notion',  1000);
+enqueueFailed('second', 'todoist', 1001);
+enqueueFailed('third',  'webhook', 1002);
+check('preserves FIFO insertion order',
+    getQueue().map(function(e) { return e.text; }).join(','),
+    'first,second,third');
+check('keeps the original dictation timestamp', getQueue()[0].ts, 1000);
+check('stores the resolved destination', getQueue()[1].dest, 'todoist');
+check('new entries start at zero tries', getQueue()[2].tries, 0);
+
+reset();
+for (var i = 0; i < MAX_QUEUE_LEN + 10; i++) enqueueFailed('n' + i, 'notion', i);
+check('caps queue length at MAX_QUEUE_LEN', getQueue().length, MAX_QUEUE_LEN);
+check('drops oldest entries when full (newest kept)',
+    getQueue()[getQueue().length - 1].text, 'n' + (MAX_QUEUE_LEN + 9));
+check('oldest surviving entry is the expected one',
+    getQueue()[0].text, 'n10');
+
+// ============================================================
+// queueAfterResult — success / failure / retry cap
+// ============================================================
+
+section('queueAfterResult — advancing the head');
+
+check('success removes the head',
+    queueAfterResult([{ text: 'a', tries: 0 }, { text: 'b', tries: 0 }], true)
+        .map(function(e) { return e.text; }).join(','),
+    'b');
+
+check('empty queue is left alone',
+    JSON.stringify(queueAfterResult([], true)), '[]');
+
+var q = [{ text: 'a', tries: 0 }, { text: 'b', tries: 0 }];
+q = queueAfterResult(q, false);
+check('failure increments the head tries', q[0].tries, 1);
+check('failure keeps the head in place (order preserved)',
+    q.map(function(e) { return e.text; }).join(','), 'a,b');
+
+section('queueAfterResult — retry cap');
+
+var poison = [{ text: 'bad', tries: 0 }, { text: 'good', tries: 0 }];
+for (var k = 0; k < MAX_QUEUE_RETRIES; k++) poison = queueAfterResult(poison, false);
+check('a permanently failing head is dropped after the cap',
+    poison.map(function(e) { return e.text; }).join(','), 'good');
+
+// ============================================================
+// End-to-end drain simulation (mirrors flushQueue control flow)
+// ============================================================
+
+section('drain simulation — outage then recovery, FIFO preserved');
+
+reset();
+enqueueFailed('note-1', 'notion',  10);
+enqueueFailed('note-2', 'todoist', 11);
+enqueueFailed('note-3', 'webhook', 12);
+
+var delivered = [];
+
+// One flush pass over the head, honouring the "stop on first failure" rule.
+// Returns true when the head was delivered (so the caller keeps draining).
+function flushOnce(online) {
+    var cur = getQueue();
+    if (!cur.length) return false;
+    var head = cur[0];
+    var ok = online;
+    if (ok) delivered.push(head.text);
+    saveQueue(queueAfterResult(getQueue(), ok));
+    return ok;
+}
+
+// Network down: one trigger fires; head fails, draining stops.
+flushOnce(false);
+check('nothing delivered while offline', delivered.join(','), '');
+check('head retry recorded, queue intact', getQueue()[0].tries, 1);
+check('order unchanged during outage',
+    getQueue().map(function(e) { return e.text; }).join(','), 'note-1,note-2,note-3');
+
+// Network back: drain until the queue empties or the head fails.
+while (flushOnce(true)) { /* keep draining */ }
+check('all notes delivered in original order once online',
+    delivered.join(','), 'note-1,note-2,note-3');
+check('queue is empty after a full drain', getQueue().length, 0);
+
+// ============================================================
+// Summary
+// ============================================================
+
+process.stdout.write('\n' + passed + ' passed, ' + failed + ' failed\n');
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #4

## Problem

When a note is transcribed on the watch, the phone routes it to the chosen destination (Google Tasks, Todoist, Notion, webhook, Nextcloud). If that HTTP send fails — a network drop, an API error, or a rate limit — `routeAndSend` reports `CONFIRM: 2` and the watch shows the "Save as local note?" fallback. The note then survives only as an on-watch reminder, and the user has to re-enter it into the real destination later. Nothing retries automatically.

Scope is exactly that gap: transcription succeeded (the text exists on the phone) but delivery failed. Capture with no phone connectivity is out of scope — without the phone link there is no transcription and nothing to queue — and is noted as possible future work in #4.

## Approach

Entirely phone-side, in `src/pkjs/index.js`:

- On a failed delivery to a queueable cloud destination, the (already-cleaned) note is queued in `localStorage` (`brain_dump_queue_v1`), tagged with its original dictation timestamp.
- The queue is flushed on the PebbleKit JS `ready` event and after any successful send.
- FIFO order is preserved; draining stops on the first failure so a still-down network doesn't burn every item's retries in one pass — the next trigger resumes where it left off.
- Per-item retries cap at 5 and the queue caps at 50 entries (oldest dropped), so a permanently failing note can't grow unbounded or block the rest forever.
- Delivery reuses the existing senders through a shared `sendToDest` dispatcher, so queued and live sends take the same path. On a successful retry the note is added to history.
- AI conversations and on-watch local notes are intentionally not queued.

No new configuration options, and the watch's existing local-save fallback is unchanged — the queue is a silent background safety net alongside it.

## What was tested

- New `test/offlineQueue.test.js` (17 checks): FIFO ordering, timestamp/destination preservation, length cap, the per-item retry cap dropping a poison head, and an end-to-end outage-then-recovery drain that confirms notes deliver in original order once back online.
- Full existing suite re-run and green: `extractTime.test.js` (162), `webhookTemplate.test.js` (7), `offlineQueue.test.js` (17).
- `node --check` on the modified `index.js`.

## Note

Opening as a **draft** deliberately. I'll mark it ready once you've had a chance to weigh in on the design in #4 and I've done a final self-review. Happy to adjust bounds, the queued-vs-not destination split, or anything else.
