### PR TITLE
Add Discord as a standalone destination

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -46,6 +46,7 @@
 #define DEST_TODOIST    5
 #define DEST_NEXTCLOUD  6
 #define DEST_NEXTCLOUD_TASKS 7
+#define DEST_DISCORD   8
 
 // Destination bitmask bits (must match pkjs DEST_MASK)
 #define DEST_BIT_TASKS     (1 << DEST_TASKS)
@@ -55,6 +56,7 @@
 #define DEST_BIT_TODOIST   (1 << DEST_TODOIST)
 #define DEST_BIT_NEXTCLOUD (1 << DEST_NEXTCLOUD)
 #define DEST_BIT_NEXTCLOUD_TASKS (1 << DEST_NEXTCLOUD_TASKS)
+#define DEST_BIT_DISCORD   (1 << DEST_DISCORD)
 
 // Ink theme — strict black & white
 #define C_SCREEN   GColorBlack
@@ -315,6 +317,7 @@ static const char *dest_full_name(int dest) {
         case DEST_TODOIST:   return "Todoist";
         case DEST_NEXTCLOUD: return "Nextcloud Notes";
         case DEST_NEXTCLOUD_TASKS: return "Nextcloud Tasks";
+        case DEST_DISCORD:   return "Discord";
         default:             return "?";
     }
 }
@@ -1105,6 +1108,7 @@ static void draw_dest_glyph(GContext *ctx, int dest, GPoint c, GColor fg) {
         case DEST_WEBHOOK:   draw_glyph_letter(ctx, 'H', c, fg); break;
         case DEST_NEXTCLOUD: draw_glyph_letter(ctx, 'C', c, fg); break;
         case DEST_NEXTCLOUD_TASKS: draw_glyph_letter(ctx, 'C', c, fg); break;
+        case DEST_DISCORD:   draw_glyph_letter(ctx, 'D', c, fg); break;
         default:             draw_glyph_letter(ctx, '?', c, fg); break;
     }
 }

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -1,5 +1,5 @@
 // Brain Dump — PebbleKit JS
-// Routes voice notes to Google Tasks / Notion / AI agent / Custom Webhook
+// Routes voice notes to Google Tasks / Notion / AI agent / Custom Webhook / Discord
 // Intent classification runs locally; no extra API call needed for routing.
 
 var KEY_CONFIG  = 'brain_dump_cfg_v1';
@@ -26,7 +26,8 @@ var s_ai_messages  = [];
 var s_last_note    = '';
 var s_clock_24h    = false;   // updated from watch on each note
 // The last failed cloud send, held until the watch reports the user's fallback
-// choice. Queued on "Retry later" (QUEUE_RETRY); dropped otherwise. { text, dest, ts }.
+// choice. Queued on "Retry later" (QUEUE_RETRY); dropped otherwise.
+// { text, dest, ts, retryState? }.
 var s_pending_retry = null;
 
 // ============================================================================
@@ -63,7 +64,7 @@ function addHistory(text, dest) {
 // When a note is transcribed but delivery to its destination fails (network
 // drop, API error, rate limit), it is queued here instead of dead-ending in
 // the on-watch fallback. The queue is FIFO and flushed on 'ready' and after
-// any successful send. Entries: { text, dest, ts, tries }.
+// any successful send. Entries: { text, dest, ts, tries, retryState? }.
 
 function getQueue() {
     try { var r = localStorage.getItem(KEY_QUEUE); return r ? JSON.parse(r) : []; }
@@ -75,9 +76,11 @@ function saveQueue(q) {
 
 // Append a failed send, preserving its original dictation timestamp. Oldest
 // entries are dropped once the queue is full so it can't grow without bound.
-function enqueueFailed(text, dest, ts) {
+function enqueueFailed(text, dest, ts, retryState) {
     var q = getQueue();
-    q.push({ text: text, dest: dest, ts: ts, tries: 0 });
+    var item = { text: text, dest: dest, ts: ts, tries: 0 };
+    if (retryState) item.retryState = retryState;
+    q.push(item);
     if (q.length > MAX_QUEUE_LEN) q = q.slice(q.length - MAX_QUEUE_LEN);
     saveQueue(q);
 }
@@ -88,10 +91,11 @@ function enqueueFailed(text, dest, ts) {
 // Re-appending means a permanently failing item cycles to the back instead of
 // head-blocking the rest of the queue. Pure — the caller reads/writes storage —
 // so it stays easy to unit-test.
-function queueAfterResult(q, ok) {
+function queueAfterResult(q, ok, retryState) {
     if (!q.length) return q;
     var item = q.shift();
     if (ok) return q;
+    if (retryState) item.retryState = retryState;
     item.tries = (item.tries || 0) + 1;
     if (item.tries < MAX_QUEUE_RETRIES) q.push(item);
     return q;
@@ -107,7 +111,8 @@ function getEnabledDests(cfg) {
     if (cfg.todoist_enabled) d.push('todoist');
     if (cfg.notion_enabled)  d.push('notion');
     if (cfg.ai_enabled)      d.push('ai');
-    if (cfg.webhook_enabled)   d.push('webhook');
+    if (cfg.webhook_enabled) d.push('webhook');
+    if (cfg.discord_enabled) d.push('discord');
     if (cfg.nextcloud_enabled) d.push('nextcloud');
     if (cfg.nextcloud_tasks_enabled) d.push('nextcloud_tasks');
     return d;
@@ -278,6 +283,16 @@ function classifyIntent(text, enabled, cfg) {
         kw.forEach(function(k) {
             k = k.trim();
             if (k && t.indexOf(k) >= 0) scores['webhook'] += 3;
+        });
+    }
+
+    // Discord: service name plus configured trigger keywords
+    if (scores['discord'] !== undefined) {
+        ['discord', 'send to discord', 'post to discord'].forEach(function(k) {
+            if (t.indexOf(k) >= 0) scores['discord'] += 4;
+        });
+        getCustomKeywords(cfg, 'discord').forEach(function(k) {
+            if (t.indexOf(k) >= 0) scores['discord'] += 3;
         });
     }
 
@@ -961,6 +976,123 @@ function sendToWebhook(text, cfg, cb) {
 }
 
 // ============================================================================
+// DISCORD
+// ============================================================================
+
+var DISCORD_MAX_DESCRIPTION_LENGTH = 4096;
+var DISCORD_AVATAR_URL =
+    'https://raw.githubusercontent.com/adrienthiery/pebble-brain-dump-app/main/icon_144x144.png';
+
+// Keep every character of a long note by spreading it over as many Discord
+// embeds as needed. Avoid splitting an emoji's UTF-16 surrogate pair.
+function splitDiscordNote(text) {
+    var note = text === undefined || text === null ? '' : String(text);
+    if (!note.trim()) return ['*Empty note*'];
+    if (note.length <= DISCORD_MAX_DESCRIPTION_LENGTH) return [note];
+
+    var chunks = [];
+    var start = 0;
+    while (start < note.length) {
+        var end = Math.min(start + DISCORD_MAX_DESCRIPTION_LENGTH, note.length);
+        if (end < note.length &&
+            note.charCodeAt(end - 1) >= 0xd800 && note.charCodeAt(end - 1) <= 0xdbff &&
+            note.charCodeAt(end) >= 0xdc00 && note.charCodeAt(end) <= 0xdfff) {
+            end--;
+        }
+        chunks.push(note.slice(start, end));
+        start = end;
+    }
+    return chunks;
+}
+
+// Discord accepts ISO timestamps on embeds and renders them in each viewer's
+// locale. Match Brain Dump's orange identity and suppress unexpected mentions.
+function buildDiscordPayloads(payload) {
+    var chunks = splitDiscordNote(payload.text);
+    var timestamp = new Date(payload.timestamp * 1000).toISOString();
+    return chunks.map(function(description, index) {
+        var embed = {
+            description: description,
+            color: 0xff9900,
+            timestamp: timestamp
+        };
+        if (chunks.length > 1) {
+            embed.footer = { text: 'Part ' + (index + 1) + ' of ' + chunks.length };
+        }
+        return {
+            username: 'Brain Dump',
+            avatar_url: DISCORD_AVATAR_URL,
+            embeds: [embed],
+            allowed_mentions: { parse: [] }
+        };
+    });
+}
+
+// Ask Discord to confirm that each message was saved before advancing to the
+// next part. Preserve thread_id and any other query parameters in pasted URLs.
+function buildDiscordWebhookUrl(url) {
+    if (/[?&]wait=/i.test(url)) {
+        return url.replace(/([?&])wait=[^&]*/i, '$1wait=true');
+    }
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') + 'wait=true';
+}
+
+// Discord returns retry_after in seconds. Prefer the response body, fall back to
+// the equivalent header, and use a small delay if neither can be parsed.
+function getDiscordRetryDelayMs(xhr) {
+    var retryAfter = null;
+    try {
+        var response = JSON.parse(xhr.responseText || '{}');
+        if (response.retry_after !== undefined) retryAfter = Number(response.retry_after);
+    } catch(e) {}
+    if (!(retryAfter >= 0) && xhr.getResponseHeader) {
+        retryAfter = Number(xhr.getResponseHeader('Retry-After'));
+    }
+    if (!(retryAfter >= 0)) retryAfter = 1;
+    return Math.ceil(retryAfter * 1000);
+}
+
+function sendToDiscord(text, cfg, cb, retryState) {
+    var url = cfg.discord_url;
+    if (!url) { cb(false, 'Discord not configured'); return; }
+
+    var payload = buildWebhookPayload(text);
+    if (retryState && retryState.timestamp) payload.timestamp = retryState.timestamp;
+    var bodies = buildDiscordPayloads(payload);
+    var firstPart = retryState && retryState.discordPart >= 0
+        ? Math.min(retryState.discordPart, bodies.length - 1)
+        : 0;
+
+    function failPart(index, message) {
+        cb(false, message, { discordPart: index, timestamp: payload.timestamp });
+    }
+
+    // Send parts sequentially so long notes remain ordered in Discord. Each part
+    // gets one rate-limit retry; a later queued retry resumes at the first unsent
+    // part so Discord never receives an already-confirmed part twice.
+    function sendPart(index, rateLimitRetries) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', buildDiscordWebhookUrl(url));
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.onload = function() {
+            var isOk = this.status >= 200 && this.status < 300;
+            if (this.status === 429 && rateLimitRetries < 1) {
+                var delay = getDiscordRetryDelayMs(this);
+                setTimeout(function() { sendPart(index, rateLimitRetries + 1); }, delay);
+                return;
+            }
+            if (!isOk) { failPart(index, 'HTTP ' + this.status); return; }
+            if (index + 1 < bodies.length) { sendPart(index + 1, 0); return; }
+            cb(true, 'discord');
+        };
+        xhr.onerror = function() { failPart(index, 'Network error'); };
+        xhr.send(JSON.stringify(bodies[index]));
+    }
+
+    sendPart(firstPart, 0);
+}
+
+// ============================================================================
 // TODOIST
 // ============================================================================
 
@@ -1319,20 +1451,21 @@ function stripDateTimeFromText(text) {
 // ROUTER
 // ============================================================================
 
-var DEST_INDEX = { tasks: 0, notion: 1, ai: 2, webhook: 3, local: 4, todoist: 5, nextcloud: 6, nextcloud_tasks: 7 };
+var DEST_INDEX = { tasks: 0, notion: 1, ai: 2, webhook: 3, local: 4, todoist: 5, nextcloud: 6, nextcloud_tasks: 7, discord: 8 };
 
-// Destinations whose delivery is a one-shot HTTP send that can be safely
-// retried later. 'ai' (a live conversation) and 'local' (saved on-watch) are
-// intentionally excluded from the retry queue.
-var QUEUEABLE_DESTS = { tasks: 1, notion: 1, webhook: 1, todoist: 1, nextcloud: 1, nextcloud_tasks: 1 };
+// Destinations whose delivery can be safely retried or resumed later. 'ai' (a
+// live conversation) and 'local' (saved on-watch) are intentionally excluded
+// from the retry queue.
+var QUEUEABLE_DESTS = { tasks: 1, notion: 1, webhook: 1, todoist: 1, nextcloud: 1, nextcloud_tasks: 1, discord: 1 };
 
 // Dispatch a note to a single cloud destination. Shared by the live router and
 // the retry-queue flush so both take exactly the same delivery path.
-function sendToDest(dest, text, cfg, cb) {
+function sendToDest(dest, text, cfg, cb, retryState) {
     switch (dest) {
         case 'tasks':           sendToTasks         (text, cfg, cb); break;
         case 'notion':          sendToNotion        (text, cfg, cb); break;
         case 'webhook':         sendToWebhook       (text, cfg, cb); break;
+        case 'discord':         sendToDiscord       (text, cfg, cb, retryState); break;
         case 'todoist':         sendToTodoist       (text, cfg, cb); break;
         case 'nextcloud':       sendToNextcloud     (text, cfg, cb); break;
         case 'nextcloud_tasks': sendToNextcloudTasks(text, cfg, cb); break;
@@ -1388,9 +1521,9 @@ function routeAndSend(text, isFollowup) {
     // Original text is still used for routing, due-date extraction, and AI context.
     var sendText = cleanNoteText(text);
 
-    var DEST_LABEL = { tasks: 'Tasks', notion: 'Notion', ai: 'AI', webhook: 'Webhook', local: 'Local', todoist: 'Todoist', nextcloud: 'Nextcloud Notes', nextcloud_tasks: 'Nextcloud Tasks' };
+    var DEST_LABEL = { tasks: 'Tasks', notion: 'Notion', ai: 'AI', webhook: 'Webhook', local: 'Local', todoist: 'Todoist', nextcloud: 'Nextcloud Notes', nextcloud_tasks: 'Nextcloud Tasks', discord: 'Discord' };
 
-    function onResult(ok, data) {
+    function onResult(ok, data, retryState) {
         if (!ok) {
             console.log('Send failed: ' + data);
             // Don't auto-queue. Remember this failed send so the watch's fallback
@@ -1399,7 +1532,7 @@ function routeAndSend(text, isFollowup) {
             // mutually exclusive avoids the duplicate note the old auto-queue +
             // local-fallback overlap could produce (#4).
             s_pending_retry = QUEUEABLE_DESTS[dest]
-                ? { text: sendText, dest: dest, ts: ts }
+                ? { text: sendText, dest: dest, ts: ts, retryState: retryState }
                 : null;
             var label = DEST_LABEL[dest] || dest;
             var msg = (label + ': ' + (data || 'Unknown error')).substring(0, 45);
@@ -1427,7 +1560,7 @@ function routeAndSend(text, isFollowup) {
     switch (dest) {
         case 'ai':    sendToAI(sendText, isFollowup, cfg, onResult); break;
         case 'local': onResult(true, 'local'); break;  // saved on-watch from s_note_buf
-        default:      sendToDest(dest, sendText, cfg, onResult);
+        default:      sendToDest(dest, sendText, cfg, onResult, { timestamp: ts });
     }
 }
 
@@ -1467,8 +1600,8 @@ function flushStep(cfg, down, rotated) {
     }
 
     var item = q[0];
-    sendToDest(item.dest, item.text, cfg, function(ok, data) {
-        saveQueue(queueAfterResult(getQueue(), ok));
+    sendToDest(item.dest, item.text, cfg, function(ok, data, retryState) {
+        saveQueue(queueAfterResult(getQueue(), ok, retryState));
         if (ok) {
             var di = DEST_INDEX[item.dest] !== undefined ? DEST_INDEX[item.dest] : 4;
             addHistory(item.text, di);
@@ -1478,7 +1611,7 @@ function flushStep(cfg, down, rotated) {
             console.log('Queued note still failing (' + item.dest + '): ' + data);
         }
         flushStep(cfg, down, 0);   // real attempt made — reset the skip counter
-    });
+    }, item.retryState);
 }
 
 // AppMessage allows only one message in flight; a second sendAppMessage before
@@ -1516,6 +1649,7 @@ function computeDestMask(cfg) {
     if (enabled.indexOf('todoist')   >= 0) mask |= 32;
     if (enabled.indexOf('nextcloud') >= 0) mask |= 64;
     if (enabled.indexOf('nextcloud_tasks') >= 0) mask |= 128;
+    if (enabled.indexOf('discord')   >= 0) mask |= 256;
     return mask;
 }
 
@@ -1607,7 +1741,8 @@ Pebble.addEventListener('appmessage', function(e) {
     // note that just failed so it retries on the next 'ready' or successful send.
     if (p.QUEUE_RETRY) {
         if (s_pending_retry) {
-            enqueueFailed(s_pending_retry.text, s_pending_retry.dest, s_pending_retry.ts);
+            enqueueFailed(s_pending_retry.text, s_pending_retry.dest, s_pending_retry.ts,
+                s_pending_retry.retryState);
             console.log('Queued for retry → ' + s_pending_retry.dest);
             s_pending_retry = null;
         }
@@ -1696,6 +1831,7 @@ function openSettings() {
     '<option value="nextcloud" ' + sel(cfg.default_dest,'nextcloud') + '>Nextcloud Notes</option>' +
     '<option value="nextcloud_tasks" ' + sel(cfg.default_dest,'nextcloud_tasks') + '>Nextcloud Tasks</option>' +
     '<option value="webhook"   ' + sel(cfg.default_dest,'webhook')   + '>Webhook</option>' +
+    '<option value="discord"   ' + sel(cfg.default_dest,'discord')   + '>Discord</option>' +
     '</select></label>' +
     '</div>' +
 
@@ -1844,6 +1980,17 @@ function openSettings() {
     ' value=\'' + esc(cfg.webhook_keywords) + '\' placeholder="send, post, hook">' +
     '</div></div>' +
 
+    // ---- Discord ----
+    '<div class="section" id="sec_discord">' +
+    '<label class="toggle-label"><input type="checkbox" id="discord_enabled" ' + chk(cfg.discord_enabled) + '>' +
+    ' Discord</label>' +
+    '<div class="fields">' +
+    'Webhook URL:<input type="text" id="discord_url" value=\'' + esc(cfg.discord_url) + '\'>' +
+    '<p class="note">Create a channel webhook under Server Settings &rarr; Integrations &rarr; Webhooks. Notes are sent as embeds with timestamps.</p>' +
+    'Routing keywords (comma-separated, added to defaults):<input type="text" id="discord_keywords"' +
+    ' value=\'' + esc(cfg.discord_keywords) + '\' placeholder="discord, post to discord, ...">' +
+    '</div></div>' +
+
     '<div class="save-bar"><button onclick="save()">Save</button></div>' +
 
     '<script>' +
@@ -1933,7 +2080,7 @@ function openSettings() {
     'function updateRoutingUI(){' +
       'var off=document.getElementById("disable_smart_routing").checked;' +
       'var def=document.getElementById("default_dest").value;' +
-      '["tasks","todoist","notion","nextcloud","nextcloud_tasks","ai","webhook"].forEach(function(d){' +
+      '["tasks","todoist","notion","nextcloud","nextcloud_tasks","ai","webhook","discord"].forEach(function(d){' +
         'var el=document.getElementById("sec_"+d);if(!el)return;' +
         'var dim=off&&d!==def;' +
         'el.style.opacity=dim?"0.5":"";' +
@@ -2045,7 +2192,10 @@ function openSettings() {
     'webhook_url:document.getElementById("webhook_url").value.trim(),' +
     'webhook_verb:document.getElementById("webhook_verb").value,' +
     'webhook_token:document.getElementById("webhook_token").value.trim(),' +
-    'webhook_keywords:document.getElementById("webhook_keywords").value.trim()' +
+    'webhook_keywords:document.getElementById("webhook_keywords").value.trim(),' +
+    'discord_enabled:document.getElementById("discord_enabled").checked,' +
+    'discord_url:document.getElementById("discord_url").value.trim(),' +
+    'discord_keywords:document.getElementById("discord_keywords").value.trim()' +
     '};' +
     '}' +
     'function save(){' +
@@ -2083,7 +2233,7 @@ Pebble.addEventListener('webviewclosed', function(e) {
         delete cfg._reopen;
         saveConfig(cfg);
         console.log('Config saved, dest mask recalculated');
-        // Re-send DEST_MASK to watch (now includes todoist + nextcloud)
+        // Re-send DEST_MASK so newly enabled destinations are available immediately.
         sendToWatch({ DEST_MASK: computeDestMask(cfg) });
         // "Save & verify target" (Notion refresh): reopen settings so the pkjs
         // probe re-runs against the just-saved target.

--- a/test/offlineQueue.test.js
+++ b/test/offlineQueue.test.js
@@ -24,16 +24,19 @@ function getQueue() {
 function saveQueue(q) {
     try { localStorage.setItem(KEY_QUEUE, JSON.stringify(q)); } catch(e) {}
 }
-function enqueueFailed(text, dest, ts) {
+function enqueueFailed(text, dest, ts, retryState) {
     var q = getQueue();
-    q.push({ text: text, dest: dest, ts: ts, tries: 0 });
+    var item = { text: text, dest: dest, ts: ts, tries: 0 };
+    if (retryState) item.retryState = retryState;
+    q.push(item);
     if (q.length > MAX_QUEUE_LEN) q = q.slice(q.length - MAX_QUEUE_LEN);
     saveQueue(q);
 }
-function queueAfterResult(q, ok) {
+function queueAfterResult(q, ok, retryState) {
     if (!q.length) return q;
     var item = q.shift();
     if (ok) return q;
+    if (retryState) item.retryState = retryState;
     item.tries = (item.tries || 0) + 1;
     if (item.tries < MAX_QUEUE_RETRIES) q.push(item);
     return q;
@@ -81,6 +84,12 @@ check('stores the resolved destination', getQueue()[1].dest, 'todoist');
 check('new entries start at zero tries', getQueue()[2].tries, 0);
 
 reset();
+enqueueFailed('split note', 'discord', 1003,
+    { discordPart: 1, timestamp: 1003 });
+checkObject('stores destination-specific retry progress', getQueue()[0].retryState,
+    { discordPart: 1, timestamp: 1003 });
+
+reset();
 for (var i = 0; i < MAX_QUEUE_LEN + 10; i++) enqueueFailed('n' + i, 'notion', i);
 check('caps queue length at MAX_QUEUE_LEN', getQueue().length, MAX_QUEUE_LEN);
 check('drops oldest entries when full (newest kept)',
@@ -109,6 +118,12 @@ check('failure moves the head to the tail (b is now next up)',
 check('failure increments tries on the re-appended item',
     q[q.length - 1].tries, 1);
 check('a re-appended item keeps its text', q[q.length - 1].text, 'a');
+
+var split = [{ text: 'split', dest: 'discord', tries: 0,
+    retryState: { discordPart: 1, timestamp: 1000 } }];
+split = queueAfterResult(split, false, { discordPart: 2, timestamp: 1000 });
+checkObject('a failed retry advances destination-specific progress',
+    split[0].retryState, { discordPart: 2, timestamp: 1000 });
 
 section('queueAfterResult — retry cap');
 

--- a/test/webhookDiscordFormat.test.js
+++ b/test/webhookDiscordFormat.test.js
@@ -1,0 +1,304 @@
+// Integration-focused tests for the standalone Discord destination.
+// Run: node test/webhookDiscordFormat.test.js
+
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var pkjsPath = path.join(__dirname, '..', 'src', 'pkjs', 'index.js');
+var watchPath = path.join(__dirname, '..', 'src', 'c', 'main.c');
+var pkjsSource = fs.readFileSync(pkjsPath, 'utf8');
+var watchSource = fs.readFileSync(watchPath, 'utf8');
+
+var listeners = {};
+var storage = {};
+var sentToWatch = [];
+var openedUrl = '';
+var scheduledTimers = [];
+
+var context = {
+    console: { log: function() {} },
+    setTimeout: function(callback, delay) {
+        scheduledTimers.push({ callback: callback, delay: delay });
+        return scheduledTimers.length;
+    },
+    localStorage: {
+        getItem: function(key) {
+            return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+        },
+        setItem: function(key, value) { storage[key] = String(value); },
+        removeItem: function(key) { delete storage[key]; }
+    },
+    Pebble: {
+        addEventListener: function(name, handler) { listeners[name] = handler; },
+        sendAppMessage: function(message, onSuccess) {
+            sentToWatch.push(message);
+            if (onSuccess) onSuccess();
+        },
+        openURL: function(url) { openedUrl = url; }
+    }
+};
+
+vm.createContext(context);
+vm.runInContext(pkjsSource, context, { filename: pkjsPath });
+
+var passed = 0;
+var failed = 0;
+
+function check(label, got, expected) {
+    if (got === expected) {
+        passed++;
+        process.stdout.write('  ✓ ' + label + '\n');
+    } else {
+        failed++;
+        process.stdout.write('  ✗ ' + label + '\n      got: ' + got + '\n expected: ' + expected + '\n');
+    }
+}
+
+function checkObject(label, got, expected) {
+    check(label, JSON.stringify(got), JSON.stringify(expected));
+}
+
+function section(name) {
+    process.stdout.write('\n' + name + '\n');
+}
+
+function resetTimers() {
+    scheduledTimers = [];
+}
+
+function installFakeXhr() {
+    var requests = [];
+
+    function FakeXhr() {
+        this.headers = {};
+        requests.push(this);
+    }
+
+    FakeXhr.prototype.open = function(method, url) {
+        this.method = method;
+        this.url = url;
+    };
+    FakeXhr.prototype.setRequestHeader = function(name, value) {
+        this.headers[name] = value;
+    };
+    FakeXhr.prototype.send = function(body) {
+        this.body = body;
+    };
+    FakeXhr.prototype.getResponseHeader = function(name) {
+        return this.responseHeaders && this.responseHeaders[name] || null;
+    };
+    FakeXhr.prototype.respond = function(status, responseText, responseHeaders) {
+        this.status = status;
+        this.responseText = responseText || '';
+        this.responseHeaders = responseHeaders || {};
+        this.onload();
+    };
+    FakeXhr.prototype.failNetwork = function() {
+        this.onerror();
+    };
+
+    context.XMLHttpRequest = FakeXhr;
+    return requests;
+}
+
+var payload = { text: 'Buy milk tomorrow', timestamp: 1770000000 };
+var discordPayload = context.buildDiscordPayloads(payload)[0];
+
+section('Discord embed styling');
+check('uses the Brain Dump sender name', discordPayload.username, 'Brain Dump');
+check('uses the Brain Dump app icon', discordPayload.avatar_url,
+    'https://raw.githubusercontent.com/adrienthiery/pebble-brain-dump-app/main/icon_144x144.png');
+check('puts the note in the embed description',
+    discordPayload.embeds[0].description, 'Buy milk tomorrow');
+check('uses the Brain Dump orange accent', discordPayload.embeds[0].color, 0xff9900);
+check('uses an ISO embed timestamp',
+    discordPayload.embeds[0].timestamp, new Date(1770000000 * 1000).toISOString());
+check('does not add a footer to a single-part note',
+    discordPayload.embeds[0].footer, undefined);
+checkObject('suppresses mentions', discordPayload.allowed_mentions, { parse: [] });
+
+section('Lossless long notes');
+var longNote = new Array(4096).join('a') + '🧠' + new Array(1001).join('b') + '\nLast line';
+var longPayloads = context.buildDiscordPayloads({ text: longNote, timestamp: 1770000000 });
+check('splits a long note into two messages', longPayloads.length, 2);
+check('keeps every character in order',
+    longPayloads.map(function(part) { return part.embeds[0].description; }).join(''),
+    longNote);
+check('keeps every part within the Discord limit',
+    longPayloads.every(function(part) {
+        return part.embeds[0].description.length <= context.DISCORD_MAX_DESCRIPTION_LENGTH;
+    }), true);
+check('labels the first part', longPayloads[0].embeds[0].footer.text, 'Part 1 of 2');
+check('labels the second part', longPayloads[1].embeds[0].footer.text, 'Part 2 of 2');
+
+section('Independent destination configuration and routing');
+checkObject('enables Custom Webhook independently',
+    context.getEnabledDests({ webhook_enabled: true }), ['webhook']);
+checkObject('enables Discord independently',
+    context.getEnabledDests({ discord_enabled: true }), ['discord']);
+checkObject('allows Custom Webhook and Discord together',
+    context.getEnabledDests({ webhook_enabled: true, discord_enabled: true }),
+    ['webhook', 'discord']);
+
+var routingCfg = {
+    routing_auto: true,
+    default_dest: 'webhook',
+    webhook_enabled: true,
+    webhook_keywords: 'automation',
+    discord_enabled: true,
+    discord_keywords: 'team chat'
+};
+var routingDests = context.getEnabledDests(routingCfg);
+check('routes built-in Discord phrases to Discord',
+    context.pickDest('Post to Discord project update', routingDests, routingCfg, false),
+    'discord');
+check('routes custom Discord keywords to Discord',
+    context.pickDest('Team chat project update', routingDests, routingCfg, false),
+    'discord');
+check('respects Discord as the default when smart routing is off',
+    context.pickDest('A plain note', routingDests, {
+        routing_auto: false,
+        default_dest: 'discord'
+    }, false), 'discord');
+check('assigns Discord its own destination-mask bit',
+    context.computeDestMask({ webhook_enabled: true, discord_enabled: true }), 264);
+check('keeps Discord eligible for the retry queue',
+    context.QUEUEABLE_DESTS.discord, 1);
+check('preserves Discord webhook query parameters when requesting confirmation',
+    context.buildDiscordWebhookUrl('https://discord.example/webhook?thread_id=123'),
+    'https://discord.example/webhook?thread_id=123&wait=true');
+check('overrides an explicitly disabled Discord confirmation response',
+    context.buildDiscordWebhookUrl('https://discord.example/webhook?wait=false'),
+    'https://discord.example/webhook?wait=true');
+
+section('Discord delivery');
+var requests = installFakeXhr();
+var deliveryResult;
+var beforeSend = Math.floor(Date.now() / 1000);
+context.sendToDest('discord', longNote, {
+    discord_url: 'https://discord.example/webhook'
+}, function(ok, data) {
+    deliveryResult = { ok: ok, data: data };
+});
+
+check('starts with only the first request in flight', requests.length, 1);
+check('uses POST for Discord webhooks', requests[0].method, 'POST');
+check('requests Discord confirmation for the configured webhook', requests[0].url,
+    'https://discord.example/webhook?wait=true');
+check('sends JSON', requests[0].headers['Content-Type'], 'application/json');
+var sentTimestamp = Date.parse(JSON.parse(requests[0].body).embeds[0].timestamp) / 1000;
+check('timestamps the embed when the note is sent',
+    sentTimestamp >= beforeSend && sentTimestamp <= Math.floor(Date.now() / 1000), true);
+check('waits for the first part before starting the second', deliveryResult, undefined);
+
+requests[0].respond(200, '{"id":"first"}');
+check('starts the second part after the first succeeds', requests.length, 2);
+check('waits for every part before reporting success', deliveryResult, undefined);
+requests[1].respond(200, '{"id":"second"}');
+checkObject('reports success after every part is delivered', deliveryResult,
+    { ok: true, data: 'discord' });
+check('sends every note character exactly once',
+    requests.map(function(request) {
+        return JSON.parse(request.body).embeds[0].description;
+    }).join(''), longNote);
+
+section('Multipart retry progress');
+var partialRequests = installFakeXhr();
+var partialFailure;
+context.sendToDiscord(longNote, { discord_url: 'https://discord.example/webhook' },
+    function(ok, data, retryState) {
+        partialFailure = { ok: ok, data: data, retryState: retryState };
+    }, { timestamp: 1770000000 });
+partialRequests[0].respond(200, '{"id":"first"}');
+partialRequests[1].respond(500);
+checkObject('records the first unsent part after a partial failure', partialFailure,
+    { ok: false, data: 'HTTP 500', retryState: {
+        discordPart: 1,
+        timestamp: 1770000000
+    } });
+
+var resumedRequests = installFakeXhr();
+var resumedDelivery;
+context.sendToDest('discord', longNote, { discord_url: 'https://discord.example/webhook' },
+    function(ok, data) { resumedDelivery = { ok: ok, data: data }; },
+    partialFailure.retryState);
+check('resumes with only the failed part in flight', resumedRequests.length, 1);
+check('does not resend the already-confirmed first part',
+    JSON.parse(resumedRequests[0].body).embeds[0].footer.text, 'Part 2 of 2');
+check('keeps the original timestamp when resuming',
+    JSON.parse(resumedRequests[0].body).embeds[0].timestamp,
+    new Date(1770000000 * 1000).toISOString());
+resumedRequests[0].respond(200, '{"id":"second"}');
+checkObject('reports success after the resumed part arrives', resumedDelivery,
+    { ok: true, data: 'discord' });
+
+section('Discord rate limits');
+resetTimers();
+var rateLimitedRequests = installFakeXhr();
+var rateLimitedDelivery;
+context.sendToDiscord('Rate-limited note', {
+    discord_url: 'https://discord.example/webhook'
+}, function(ok, data) {
+    rateLimitedDelivery = { ok: ok, data: data };
+});
+rateLimitedRequests[0].respond(429, '{"retry_after":0.25}');
+check('waits instead of failing immediately on a 429', rateLimitedDelivery, undefined);
+check('uses Discord retry_after as milliseconds', scheduledTimers[0].delay, 250);
+var firstRateLimitedBody = rateLimitedRequests[0].body;
+scheduledTimers.shift().callback();
+check('retries the same part after the delay', rateLimitedRequests.length, 2);
+check('keeps the payload unchanged for the rate-limit retry',
+    rateLimitedRequests[1].body, firstRateLimitedBody);
+rateLimitedRequests[1].respond(200, '{"id":"retry"}');
+checkObject('succeeds when the one-time rate-limit retry arrives', rateLimitedDelivery,
+    { ok: true, data: 'discord' });
+
+resetTimers();
+var repeatedRateLimitRequests = installFakeXhr();
+var repeatedRateLimitFailure;
+context.sendToDiscord('Still rate-limited', {
+    discord_url: 'https://discord.example/webhook'
+}, function(ok, data, retryState) {
+    repeatedRateLimitFailure = { ok: ok, data: data, retryState: retryState };
+}, { timestamp: 1770000000 });
+repeatedRateLimitRequests[0].respond(429, '{"retry_after":0.1}');
+scheduledTimers.shift().callback();
+repeatedRateLimitRequests[1].respond(429, '{"retry_after":0.1}');
+checkObject('fails after one rate-limit retry', repeatedRateLimitFailure,
+    { ok: false, data: 'HTTP 429', retryState: {
+        discordPart: 0,
+        timestamp: 1770000000
+    } });
+check('does not schedule a second rate-limit retry', scheduledTimers.length, 0);
+
+section('Settings and watch wiring');
+var savedCfg = {
+    webhook_enabled: true,
+    webhook_url: 'https://generic.example/hook',
+    discord_enabled: true,
+    discord_url: 'https://discord.example/webhook',
+    discord_keywords: 'team chat'
+};
+listeners.webviewclosed({
+    response: encodeURIComponent(JSON.stringify(savedCfg))
+});
+checkObject('persists Discord independently from Custom Webhook',
+    JSON.parse(storage.brain_dump_cfg_v1), savedCfg);
+check('updates the watch mask after saving Discord settings',
+    sentToWatch[sentToWatch.length - 1].DEST_MASK, 264);
+
+context.openSettings();
+var settingsHtml = decodeURIComponent(openedUrl.substring(openedUrl.indexOf(',') + 1));
+check('renders dedicated Discord enable and URL controls',
+    settingsHtml.indexOf('id="discord_enabled"') >= 0 &&
+    settingsHtml.indexOf('id="discord_url"') >= 0, true);
+check('assigns Discord its own watch destination index',
+    /#define DEST_DISCORD\s+8/.test(watchSource), true);
+check('shows Discord by name on the watch',
+    /case DEST_DISCORD:\s+return "Discord"/.test(watchSource), true);
+check('renders a Discord glyph on the watch',
+    /case DEST_DISCORD:\s+draw_glyph_letter\(ctx, 'D'/.test(watchSource), true);
+
+process.stdout.write('\nPassed: ' + passed + '  Failed: ' + failed + '\n');
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Problem

Discord's webhook execute endpoint requires a Discord-specific message shape. The existing Custom Webhook destination sends `{"text": ..., "timestamp": ...}`, so pointing it at a Discord channel webhook URL does not work without a relay.

Example relay and reference behavior: https://github.com/JoLeungGitHub/braindump-relay

<img width="309" height="142" alt="image" src="https://github.com/user-attachments/assets/269ba52e-dd0e-4ff0-9953-09e6a559451e" />

## What this adds

A first-class **Discord** destination, separate from Custom Webhook.

- Discord and Custom Webhook can be enabled and configured at the same time
- Adds a dedicated Discord webhook URL and routing keywords
- Adds Discord to the default-destination selector, smart routing, retry queue, history, and watch status UI
- Sends branded embeds under the `Brain Dump` sender name and app icon
- Uses Brain Dump's orange `#ff9900` accent
- Sends an ISO embed timestamp, which Discord renders in each viewer's timezone and locale
- Suppresses mentions so dictated text cannot unexpectedly ping Discord users
- Splits notes longer than Discord's 4,096-character embed-description limit across sequential messages without discarding text, labeled `Part 1 of 2`, `Part 2 of 2`, and so on
- Requests Discord confirmation for each message before reporting delivery or advancing to the next part
- Resumes queued multipart retries at the first unsent part, avoiding duplicates of parts Discord already confirmed
- On HTTP 429, waits for Discord's `retry_after` delay and retries that part once before failing

Custom Webhook remains generic and unchanged: its methods, bearer token, response handling, and `{text}` / `{timestamp}` / `{json}` URL templating continue to work as before.

## Testing

- Runs the real PebbleKit JS in a mocked Pebble environment with 50 Discord assertions covering styling, timestamps, mention suppression, lossless Unicode-safe splitting, sequential confirmed delivery, resumable multipart failures, one-time 429 backoff, independent configuration, routing, retry eligibility, settings persistence, destination masks, and watch UI wiring
- All four JavaScript test files pass with 244 assertions total
- `node --check src/pkjs/index.js`, `node --check test/webhookDiscordFormat.test.js`, and `git diff --check` pass
